### PR TITLE
Replace OpenMP with DO CONCURRENT and general improvements

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -201,4 +201,4 @@ favicon             = "logo/logo.png"
 
 
 [extra.fortitude.check]
-ignore = ["S001", "S061", "C003", "C121", "C092"]
+ignore = ["S001", "S061", "C003", "C121"]

--- a/src/forcad_nurbs_curve.f90
+++ b/src/forcad_nurbs_curve.f90
@@ -1137,7 +1137,7 @@ contains
         class(nurbs_curve), intent(inout) :: this
         real(rk), intent(in), contiguous :: Xth(:)
         integer, intent(in), contiguous :: r(:)
-        integer :: k, i, s, dim, j, n_new
+        integer :: k, i, s, d, j, n_new
         real(rk), allocatable :: Xcw(:,:), Xcw_new(:,:), Xc_new(:,:), Wc_new(:), knot_new(:)
 
         if (this%is_rational()) then ! NURBS
@@ -1150,13 +1150,13 @@ contains
                     s = 0
                 end if
 
-                dim = size(this%Xc,2)
-                allocate(Xcw(size(this%Xc,1),dim+1))
+                d = size(this%Xc,2)
+                allocate(Xcw(size(this%Xc,1),d+1))
 
                 do j = 1, size(this%Xc,1)
-                    Xcw(j,1:dim) = this%Xc(j,1:dim)*this%Wc(j)
+                    Xcw(j,1:d) = this%Xc(j,1:d)*this%Wc(j)
                 end do
-                Xcw(:,dim+1) = this%Wc(:)
+                Xcw(:,d+1) = this%Wc(:)
 
                 call insert_knot_A_5_1(&
                     this%degree,&
@@ -1170,11 +1170,11 @@ contains
                     knot_new,&
                     Xcw_new)
 
-                allocate(Xc_new(1:n_new+1,1:dim))
+                allocate(Xc_new(1:n_new+1,1:d))
                 allocate(Wc_new(1:n_new+1))
                 do j = 1, n_new+1
-                    Xc_new(j,1:dim) = Xcw_new(j-1,1:dim)/Xcw_new(j-1,dim+1)
-                    Wc_new(j) = Xcw_new(j-1,dim+1)
+                    Xc_new(j,1:d) = Xcw_new(j-1,1:d)/Xcw_new(j-1,d+1)
+                    Wc_new(j) = Xcw_new(j-1,d+1)
                 end do
 
                 call this%set(knot=knot_new, Xc=Xc_new, Wc=Wc_new)
@@ -1219,32 +1219,32 @@ contains
         class(nurbs_curve), intent(inout) :: this
         integer, intent(in) :: t
         real(rk), allocatable :: Xcw(:,:), Xcw_new(:,:), knot_new(:), Xc_new(:,:), Wc_new(:)
-        integer :: dim, j, nc_new
+        integer :: d, j, nc_new
 
         if (this%is_rational()) then ! NURBS
 
-            dim = size(this%Xc,2)
-            allocate(Xcw(size(this%Xc,1),dim+1))
+            d = size(this%Xc,2)
+            allocate(Xcw(size(this%Xc,1),d+1))
             do j = 1, size(this%Xc,1)
-                Xcw(j,1:dim) = this%Xc(j,1:dim)*this%Wc(j)
-                Xcw(j,dim+1) = this%Wc(j)
+                Xcw(j,1:d) = this%Xc(j,1:d)*this%Wc(j)
+                Xcw(j,d+1) = this%Wc(j)
             end do
 
             call elevate_degree_A_5_9(t, this%knot, this%degree, Xcw, nc_new, knot_new, Xcw_new)
 
-            allocate(Xc_new(1:nc_new,1:dim))
+            allocate(Xc_new(1:nc_new,1:d))
             allocate(Wc_new(1:nc_new))
             do j = 1, nc_new
-                Xc_new(j,1:dim) = Xcw_new(j,1:dim)/Xcw_new(j,dim+1)
+                Xc_new(j,1:d) = Xcw_new(j,1:d)/Xcw_new(j,d+1)
             end do
-            Wc_new(:) = Xcw_new(:,dim+1)
+            Wc_new(:) = Xcw_new(:,d+1)
 
             call this%set(knot=knot_new, Xc=Xc_new, Wc=Wc_new)
             deallocate(Xcw, Xcw_new, Xc_new, Wc_new)
 
         else ! B-Spline
 
-            dim = size(this%Xc,2)
+            d = size(this%Xc,2)
 
             call elevate_degree_A_5_9(t, this%knot, this%degree, this%Xc, nc_new, knot_new, Xc_new)
 
@@ -1516,7 +1516,7 @@ contains
         class(nurbs_curve), intent(inout) :: this
         real(rk), intent(in), contiguous :: Xth(:)
         integer, intent(in), contiguous :: r(:)
-        integer :: k, i, s, dim, j, nc_new, t
+        integer :: k, i, s, d, j, nc_new, t
         real(rk), allocatable :: Xcw(:,:), Xcw_new(:,:), Xc_new(:,:), Wc_new(:), knot_new(:)
 
         if (this%is_rational()) then ! NURBS
@@ -1530,12 +1530,12 @@ contains
                 end if
                 k = k + 1
 
-                dim = size(this%Xc,2)
-                allocate(Xcw(size(this%Xc,1),dim+1))
+                d = size(this%Xc,2)
+                allocate(Xcw(size(this%Xc,1),d+1))
                 do j = 1, size(this%Xc,1)
-                    Xcw(j,1:dim) = this%Xc(j,1:dim)*this%Wc(j)
+                    Xcw(j,1:d) = this%Xc(j,1:d)*this%Wc(j)
                 end do
-                Xcw(:,dim+1) = this%Wc(:)
+                Xcw(:,d+1) = this%Wc(:)
 
                 call remove_knots_A_5_8(&
                     this%degree,&
@@ -1555,12 +1555,12 @@ contains
                     ! no change
                 else
                     nc_new = size(Xcw_new,1)
-                    allocate(Xc_new(nc_new,dim))
+                    allocate(Xc_new(nc_new,d))
                     allocate(Wc_new(nc_new))
                     do j = 1, nc_new
-                        Xc_new(j,:) = Xcw_new(j,1:dim)/Xcw_new(j,dim+1)
+                        Xc_new(j,:) = Xcw_new(j,1:d)/Xcw_new(j,d+1)
                     end do
-                    Wc_new(:) = Xcw_new(:,dim+1)
+                    Wc_new(:) = Xcw_new(:,d+1)
 
                     call this%set(knot=knot_new, Xc=Xc_new, Wc=Wc_new)
                     if (allocated(Xcw_new)) deallocate(Xcw_new)

--- a/src/forcad_nurbs_curve.f90
+++ b/src/forcad_nurbs_curve.f90
@@ -6,7 +6,7 @@ module forcad_nurbs_curve
     use forcad_kinds, only: rk
     use forcad_utils, only: basis_bspline, elemConn_C0, ndgrid, compute_multiplicity, compute_knot_vector, basis_bspline_der,&
         insert_knot_A_5_1, findspan, elevate_degree_A_5_9, remove_knots_A_5_8, &
-        elemConn_Cn, unique, rotation, dyad, gauss_leg, export_vtk_legacy
+        elemConn_Cn, unique, rotation, dyad, gauss_leg, export_vtk_legacy, basis_bspline_2der
 
     implicit none
 
@@ -105,219 +105,34 @@ module forcad_nurbs_curve
     end type
     !===============================================================================
 
-
     interface compute_Xg
-        pure function compute_Xg_nurbs_1d(f_Xt, f_knot, f_degree, f_nc, f_ng, f_Xc, f_Wc) result(f_Xg)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot(:)
-            integer, intent(in) :: f_degree
-            integer, intent(in) :: f_nc
-            integer, intent(in) :: f_ng
-            real(rk), intent(in), contiguous :: f_Xc(:,:)
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable :: f_Xg(:,:)
-        end function
-
-        pure function compute_Xg_bspline_1d(f_Xt, f_knot, f_degree, f_nc, f_ng, f_Xc) result(f_Xg)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot(:)
-            integer, intent(in) :: f_degree
-            integer, intent(in) :: f_nc
-            integer, intent(in) :: f_ng
-            real(rk), intent(in), contiguous :: f_Xc(:,:)
-            real(rk), allocatable :: f_Xg(:,:)
-        end function
-
-        pure function compute_Xg_nurbs_1d_1point(f_Xt, f_knot, f_degree, f_nc, f_Xc, f_Wc) result(f_Xg)
-            import :: rk
-            implicit none
-            real(rk), intent(in) :: f_Xt
-            real(rk), intent(in), contiguous :: f_knot(:)
-            integer, intent(in) :: f_degree
-            integer, intent(in) :: f_nc
-            real(rk), intent(in), contiguous :: f_Xc(:,:)
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable :: f_Xg(:)
-        end function
-
-        pure function compute_Xg_bspline_1d_1point(f_Xt, f_knot, f_degree, f_nc, f_Xc) result(f_Xg)
-            import :: rk
-            implicit none
-            real(rk), intent(in) :: f_Xt
-            real(rk), intent(in), contiguous :: f_knot(:)
-            integer, intent(in) :: f_degree
-            integer, intent(in) :: f_nc
-            real(rk), intent(in), contiguous :: f_Xc(:,:)
-            real(rk), allocatable :: f_Xg(:)
-        end function
-    end interface
-
-    interface compute_d2Tgc
-        pure subroutine compute_d2Tgc_nurbs_1d_vector(f_Xt, f_knot, f_degree, f_nc, f_ng, f_Wc, f_d2Tgc, f_dTgc, f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot(:)
-            integer, intent(in) :: f_degree
-            integer, intent(in) :: f_nc
-            integer, intent(in) :: f_ng
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable, intent(out) :: f_d2Tgc(:,:)
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:,:)
-        end subroutine
-
-        pure subroutine compute_d2Tgc_bspline_1d_vector(f_Xt, f_knot, f_degree, f_nc, f_ng, f_d2Tgc, f_dTgc, f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot(:)
-            integer, intent(in) :: f_degree
-            integer, intent(in) :: f_nc
-            integer, intent(in) :: f_ng
-            real(rk), allocatable, intent(out) :: f_d2Tgc(:,:)
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:,:)
-        end subroutine
-
-        pure subroutine compute_d2Tgc_nurbs_1d_scalar(f_Xt, f_knot, f_degree, f_nc, f_Wc, f_d2Tgc, f_dTgc, f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in) :: f_Xt
-            real(rk), intent(in), contiguous :: f_knot(:)
-            integer, intent(in) :: f_degree
-            integer, intent(in) :: f_nc
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable, intent(out) :: f_d2Tgc(:)
-            real(rk), allocatable, intent(out) :: f_dTgc(:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:)
-        end subroutine
-
-        pure subroutine compute_d2Tgc_bspline_1d_scalar(f_Xt, f_knot, f_degree, f_nc, f_d2Tgc, f_dTgc, f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in) :: f_Xt
-            real(rk), intent(in), contiguous :: f_knot(:)
-            integer, intent(in) :: f_degree
-            integer, intent(in) :: f_nc
-            real(rk), allocatable, intent(out) :: f_d2Tgc(:)
-            real(rk), allocatable, intent(out) :: f_dTgc(:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:)
-        end subroutine
-    end interface
-
-    interface compute_dTgc
-        pure subroutine compute_dTgc_nurbs_1d_vector(f_Xt, f_knot, f_degree, f_nc, f_ng, f_Wc, f_dTgc, f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot(:)
-            integer, intent(in) :: f_degree
-            integer, intent(in) :: f_nc
-            integer, intent(in) :: f_ng
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:,:)
-        end subroutine
-
-        pure subroutine compute_dTgc_bspline_1d_vector(f_Xt, f_knot, f_degree, f_nc, f_ng, f_dTgc, f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot(:)
-            integer, intent(in) :: f_degree
-            integer, intent(in) :: f_nc
-            integer, intent(in) :: f_ng
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:,:)
-        end subroutine
-
-        pure subroutine compute_dTgc_nurbs_1d_scalar(f_Xt, f_knot, f_degree, f_nc, f_Wc, f_dTgc, f_Tgc, f_elem)
-            import :: rk
-            implicit none
-            real(rk), intent(in) :: f_Xt
-            real(rk), intent(in), contiguous :: f_knot(:)
-            integer, intent(in) :: f_degree
-            integer, intent(in) :: f_nc
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable, intent(out) :: f_dTgc(:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:)
-            integer, intent(in), optional :: f_elem(:)
-        end subroutine
-
-        pure subroutine compute_dTgc_bspline_1d_scalar(f_Xt, f_knot, f_degree, f_nc, f_dTgc, f_Tgc, f_elem)
-            import :: rk
-            implicit none
-            real(rk), intent(in) :: f_Xt
-            real(rk), intent(in), contiguous :: f_knot(:)
-            integer, intent(in) :: f_degree
-            integer, intent(in) :: f_nc
-            real(rk), allocatable, intent(out) :: f_dTgc(:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:)
-            integer, intent(in), optional :: f_elem(:)
-        end subroutine
+        module procedure compute_Xg_nurbs_1d
+        module procedure compute_Xg_bspline_1d
+        module procedure compute_Xg_nurbs_1d_1point
+        module procedure compute_Xg_bspline_1d_1point
     end interface
 
     interface compute_Tgc
-        pure function compute_Tgc_nurbs_1d_vector(f_Xt, f_knot, f_degree, f_nc, f_ng, f_Wc) result(f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot(:)
-            integer, intent(in) :: f_degree
-            integer, intent(in) :: f_nc
-            integer, intent(in) :: f_ng
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable :: f_Tgc(:,:)
-        end function
-
-        pure function compute_Tgc_bspline_1d_vector(f_Xt, f_knot, f_degree, f_nc, f_ng) result(f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot(:)
-            integer, intent(in) :: f_degree
-            integer, intent(in) :: f_nc
-            integer, intent(in) :: f_ng
-            real(rk), allocatable :: f_Tgc(:,:)
-        end function
-
-        pure function compute_Tgc_nurbs_1d_scalar(f_Xt, f_knot, f_degree, f_nc, f_Wc) result(f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in) :: f_Xt
-            real(rk), intent(in), contiguous :: f_knot(:)
-            integer, intent(in) :: f_degree
-            integer, intent(in) :: f_nc
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable :: f_Tgc(:)
-        end function
-
-        pure function compute_Tgc_bspline_1d_scalar(f_Xt, f_knot, f_degree, f_nc) result(f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in) :: f_Xt
-            real(rk), intent(in), contiguous :: f_knot(:)
-            integer, intent(in) :: f_degree
-            integer, intent(in) :: f_nc
-            real(rk), allocatable :: f_Tgc(:)
-        end function
+        module procedure compute_Tgc_nurbs_1d_vector
+        module procedure compute_Tgc_bspline_1d_vector
+        module procedure compute_Tgc_nurbs_1d_scalar
+        module procedure compute_Tgc_bspline_1d_scalar
     end interface
 
-    interface
-        pure function nearest_point_help_1d(f_ng, f_Xg, f_point_Xg) result(f_distances)
-            import :: rk
-            implicit none
-            integer, intent(in) :: f_ng
-            real(rk), intent(in), contiguous :: f_Xg(:,:)
-            real(rk), intent(in), contiguous :: f_point_Xg(:)
-            real(rk), allocatable :: f_distances(:)
-        end function
+    interface compute_dTgc
+        module procedure compute_dTgc_nurbs_1d_vector
+        module procedure compute_dTgc_bspline_1d_vector
+        module procedure compute_dTgc_nurbs_1d_scalar
+        module procedure compute_dTgc_bspline_1d_scalar
     end interface
+
+    interface compute_d2Tgc
+        module procedure compute_d2Tgc_nurbs_1d_vector
+        module procedure compute_d2Tgc_bspline_1d_vector
+        module procedure compute_d2Tgc_nurbs_1d_scalar
+        module procedure compute_d2Tgc_bspline_1d_scalar
+    end interface
+
 
 contains
 
@@ -1025,7 +840,7 @@ contains
         ! Cleanup
         call Dlist%delete()
         call Plist%delete()
-    end subroutine export_iges
+    end subroutine
     !===============================================================================
 
 
@@ -2088,463 +1903,399 @@ contains
     end subroutine
     !===============================================================================
 
-end module forcad_nurbs_curve
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Xg_nurbs_1d(Xt, knot, degree, nc, ng, Xc, Wc) result(Xg)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function cmp_Tgc_1d(Xti, knot, nc, degree, Wc) result(Tgc)
+        real(rk), intent(in) :: Xti
+        real(rk), intent(in), contiguous :: knot(:)
+        integer, intent(in) :: degree, nc
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk) :: Tgc(nc)
+        real(rk) :: tmp
+        integer :: i
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot(:)
-    integer, intent(in) :: degree
-    integer, intent(in) :: nc
-    integer, intent(in) :: ng
-    real(rk), intent(in), contiguous :: Xc(:,:)
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable :: Xg(:,:)
-    real(rk), allocatable :: Tgc(:)
-    integer :: i
+        Tgc = basis_bspline(Xti, knot, nc, degree)
+        tmp = dot_product(Tgc, Wc)
+        do concurrent (i = 1: nc)
+           Tgc(i) = (Tgc(i) * Wc(i)) / tmp
+        end do
+    end function
+    !===============================================================================
 
-    allocate(Xg(ng, size(Xc,2)))
-    allocate(Tgc(nc))
-    !$omp parallel do private(Tgc)
-    do i = 1, ng
-        Tgc = basis_bspline(Xt(i), knot, nc, degree)
+
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Xg_nurbs_1d(Xt, knot, degree, nc, ng, Xc, Wc) result(Xg)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot(:)
+        integer, intent(in) :: degree
+        integer, intent(in) :: nc
+        integer, intent(in) :: ng
+        real(rk), intent(in), contiguous :: Xc(:,:)
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable :: Xg(:,:)
+        integer :: i
+
+        allocate(Xg(ng, size(Xc,2)), source = 0.0_rk)
+        do concurrent (i = 1: ng)
+            Xg(i,:) = matmul(cmp_Tgc_1d(Xt(i), knot, nc, degree, Wc), Xc)
+        end do
+    end function
+    !===============================================================================
+
+
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Xg_nurbs_1d_1point(Xt, knot, degree, nc, Xc, Wc) result(Xg)
+        real(rk), intent(in) :: Xt
+        real(rk), intent(in), contiguous :: knot(:)
+        integer, intent(in) :: degree
+        integer, intent(in) :: nc
+        real(rk), intent(in), contiguous :: Xc(:,:)
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable :: Xg(:)
+        real(rk), allocatable :: Tgc(:)
+
+        allocate(Xg(size(Xc)))
+        allocate(Tgc(nc))
+        Tgc = basis_bspline(Xt, knot, nc, degree)
         Tgc = Tgc*(Wc/(dot_product(Tgc,Wc)))
-        Xg(i,:) = matmul(Tgc, Xc)
-    end do
-    !$omp end parallel do
-end function
-!===============================================================================
+        Xg = matmul(Tgc, Xc)
+    end function
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Xg_nurbs_1d_1point(Xt, knot, degree, nc, Xc, Wc) result(Xg)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Xg_bspline_1d(Xt, knot, degree, nc, ng, Xc) result(Xg)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot(:)
+        integer, intent(in) :: degree
+        integer, intent(in) :: nc
+        integer, intent(in) :: ng
+        real(rk), intent(in), contiguous :: Xc(:,:)
+        real(rk), allocatable :: Xg(:,:)
+        integer :: i
 
-    implicit none
-    real(rk), intent(in) :: Xt
-    real(rk), intent(in), contiguous :: knot(:)
-    integer, intent(in) :: degree
-    integer, intent(in) :: nc
-    real(rk), intent(in), contiguous :: Xc(:,:)
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable :: Xg(:)
-    real(rk), allocatable :: Tgc(:)
-
-    allocate(Xg(size(Xc)))
-    allocate(Tgc(nc))
-    Tgc = basis_bspline(Xt, knot, nc, degree)
-    Tgc = Tgc*(Wc/(dot_product(Tgc,Wc)))
-    Xg = matmul(Tgc, Xc)
-end function
-!===============================================================================
+        allocate(Xg(ng, size(Xc,2)))
+        do concurrent (i = 1: ng)
+            Xg(i,:) = matmul(basis_bspline(Xt(i), knot, nc, degree), Xc)
+        end do
+    end function
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Xg_bspline_1d(Xt, knot, degree, nc, ng, Xc) result(Xg)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Xg_bspline_1d_1point(Xt, knot, degree, nc, Xc) result(Xg)
+        real(rk), intent(in) :: Xt
+        real(rk), intent(in), contiguous :: knot(:)
+        integer, intent(in) :: degree
+        integer, intent(in) :: nc
+        real(rk), intent(in), contiguous :: Xc(:,:)
+        real(rk), allocatable :: Xg(:)
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot(:)
-    integer, intent(in) :: degree
-    integer, intent(in) :: nc
-    integer, intent(in) :: ng
-    real(rk), intent(in), contiguous :: Xc(:,:)
-    real(rk), allocatable :: Xg(:,:)
-    integer :: i
-
-    allocate(Xg(ng, size(Xc,2)))
-    !$omp parallel do
-    do i = 1, ng
-        Xg(i,:) = matmul(basis_bspline(Xt(i), knot, nc, degree), Xc)
-    end do
-    !$omp end parallel do
-end function
-!===============================================================================
+        allocate(Xg(size(Xc)))
+        Xg = matmul(basis_bspline(Xt, knot, nc, degree), Xc)
+    end function
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Xg_bspline_1d_1point(Xt, knot, degree, nc, Xc) result(Xg)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_d2Tgc_nurbs_1d_vector(Xt, knot, degree, nc, ng, Wc, d2Tgc, dTgc, Tgc)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot(:)
+        integer, intent(in) :: degree
+        integer, intent(in) :: nc
+        integer, intent(in) :: ng
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable, intent(out) :: d2Tgc(:,:)
+        real(rk), allocatable, intent(out) :: dTgc(:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:,:)
+        real(rk), allocatable :: d2Bi(:), dBi(:), Tgci(:), dTgci(:), Bi(:)
+        integer :: i
 
-    implicit none
-    real(rk), intent(in) :: Xt
-    real(rk), intent(in), contiguous :: knot(:)
-    integer, intent(in) :: degree
-    integer, intent(in) :: nc
-    real(rk), intent(in), contiguous :: Xc(:,:)
-    real(rk), allocatable :: Xg(:)
+        allocate(d2Tgc(ng, nc), dTgc(ng, nc), Tgc(ng, nc), d2Bi(nc), dTgci(nc), dBi(nc), Tgci(nc), Bi(nc))
 
-    allocate(Xg(size(Xc)))
-    Xg = matmul(basis_bspline(Xt, knot, nc, degree), Xc)
-end function
-!===============================================================================
+        do concurrent (i = 1: size(Xt))
+            call basis_bspline_2der(Xt(i), knot, nc, degree, d2Bi, dBi, Bi)
+            Tgci = Bi*(Wc/(dot_product(Bi,Wc)))
+            Tgc(i,:) = Tgci
 
+            dTgci = ( dBi*Wc - Tgci*dot_product(dBi,Wc) ) / dot_product(Bi,Wc)
+            dTgc(i,:) = dTgci
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_dTgc_nurbs_1d_vector(Xt, knot, degree, nc, ng, Wc, dTgc, Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_der
-
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot(:)
-    integer, intent(in) :: degree
-    integer, intent(in) :: nc
-    integer, intent(in) :: ng
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable, intent(out) :: dTgc(:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:,:)
-    real(rk), allocatable :: dBi(:), Bi(:)
-    integer :: i
-
-    allocate(dTgc(ng, nc), Tgc(ng, nc), dBi(nc), Bi(nc))
-    do i = 1, size(Xt)
-        call basis_bspline_der(Xt(i), knot, nc, degree, dBi, Bi)
-        Tgc(i,:) = Bi*(Wc/(dot_product(Bi,Wc)))
-        dTgc(i,:) = ( dBi*Wc - Tgc(i,:)*dot_product(dBi,Wc) ) / dot_product(Bi,Wc)
-    end do
-end subroutine
-!===============================================================================
+            d2Tgc(i,:) = (d2Bi*Wc - 2.0_rk*dTgci*dot_product(dBi,Wc) - Tgci*dot_product(d2Bi,Wc)) / dot_product(Bi,Wc)
+        end do
+    end subroutine
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_dTgc_nurbs_1d_scalar(Xt, knot, degree, nc, Wc, dTgc, Tgc, elem)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_der
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_d2Tgc_nurbs_1d_scalar(Xt, knot, degree, nc, Wc, d2Tgc, dTgc, Tgc)
+        real(rk), intent(in) :: Xt
+        real(rk), intent(in), contiguous :: knot(:)
+        integer, intent(in) :: degree
+        integer, intent(in) :: nc
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable, intent(out) :: d2Tgc(:)
+        real(rk), allocatable, intent(out) :: dTgc(:)
+        real(rk), allocatable, intent(out) :: Tgc(:)
+        real(rk), allocatable :: d2Bi(:), dBi(:), Bi(:)
 
-    implicit none
-    real(rk), intent(in) :: Xt
-    real(rk), intent(in), contiguous :: knot(:)
-    integer, intent(in) :: degree
-    integer, intent(in) :: nc
-    real(rk), intent(in), contiguous :: Wc(:)
-    integer, intent(in), optional :: elem(:)
-    real(rk), allocatable, intent(out) :: dTgc(:)
-    real(rk), allocatable, intent(out) :: Tgc(:)
-    real(rk), allocatable :: dBi(:), Bi(:)
+        allocate(d2Tgc(nc), dTgc(nc), Tgc(nc), d2Bi(nc), dBi(nc), Bi(nc))
 
-    call basis_bspline_der(Xt, knot, nc, degree, dBi, Bi)
-
-    if (.not. present(elem)) then
-        allocate(dTgc(nc), Tgc(nc))
+        call basis_bspline_2der(Xt, knot, nc, degree, d2Bi, dBi, Bi)
         Tgc = Bi*(Wc/(dot_product(Bi,Wc)))
         dTgc = ( dBi*Wc - Tgc*dot_product(dBi,Wc) ) / dot_product(Bi,Wc)
-    else
-        allocate(dTgc(size(elem)), Tgc(size(elem)))
-        Tgc = Bi(elem)*(Wc(elem)/(dot_product(Bi(elem),Wc(elem))))
-        dTgc = ( dBi(elem)*Wc(elem) - Tgc*dot_product(dBi(elem),Wc(elem)) ) / dot_product(Bi(elem),Wc(elem))
-    end if
-end subroutine
-!===============================================================================
+        d2Tgc = (d2Bi*Wc - 2.0_rk*dTgc*dot_product(dBi,Wc) - Tgc*dot_product(d2Bi,Wc)) / dot_product(Bi,Wc)
+    end subroutine
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_dTgc_bspline_1d_vector(Xt, knot, degree, nc, ng, dTgc, Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_der
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_d2Tgc_bspline_1d_vector(Xt, knot, degree, nc, ng, d2Tgc, dTgc, Tgc)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot(:)
+        integer, intent(in) :: degree
+        integer, intent(in) :: nc
+        integer, intent(in) :: ng
+        real(rk), allocatable, intent(out) :: d2Tgc(:,:)
+        real(rk), allocatable, intent(out) :: dTgc(:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:,:)
+        integer :: i
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot(:)
-    integer, intent(in) :: degree
-    integer, intent(in) :: nc
-    integer, intent(in) :: ng
-    real(rk), allocatable, intent(out) :: dTgc(:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:,:)
-    real(rk), allocatable :: dBi(:), Bi(:)
-    integer :: i
-
-    allocate(dTgc(ng, nc), Tgc(ng, nc), dBi(nc), Bi(nc))
-    do i = 1, size(Xt)
-        call basis_bspline_der(Xt(i), knot, nc, degree, dBi, Bi)
-        Tgc(i,:) = Bi
-        dTgc(i,:) = dBi
-    end do
-end subroutine
-!===============================================================================
+        allocate(d2Tgc(ng, nc), dTgc(ng, nc), Tgc(ng, nc))
+        do concurrent (i = 1: size(Xt))
+            call basis_bspline_2der(Xt(i), knot, nc, degree, d2Tgc(i,:) , dTgc(i,:), Tgc(i,:))
+        end do
+    end subroutine
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_dTgc_bspline_1d_scalar(Xt, knot, degree, nc, dTgc, Tgc, elem)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_der
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_d2Tgc_bspline_1d_scalar(Xt, knot, degree, nc, d2Tgc, dTgc, Tgc)
+        real(rk), intent(in) :: Xt
+        real(rk), intent(in), contiguous :: knot(:)
+        integer, intent(in) :: degree
+        integer, intent(in) :: nc
+        real(rk), allocatable, intent(out) :: d2Tgc(:)
+        real(rk), allocatable, intent(out) :: dTgc(:)
+        real(rk), allocatable, intent(out) :: Tgc(:)
 
-    implicit none
-    real(rk), intent(in) :: Xt
-    real(rk), intent(in), contiguous :: knot(:)
-    integer, intent(in) :: degree
-    integer, intent(in) :: nc
-    integer, intent(in), optional :: elem(:)
-    real(rk), allocatable, intent(out) :: dTgc(:)
-    real(rk), allocatable, intent(out) :: Tgc(:)
-    real(rk), allocatable :: dB(:), B(:)
-
-    if (.not. present(elem)) then
-        allocate(dTgc(nc), Tgc(nc))
-        call basis_bspline_der(Xt, knot, nc, degree, dTgc, Tgc)
-    else
-        allocate(dB(size(elem)), B(size(elem)))
-        call basis_bspline_der(Xt, knot, nc, degree, dB, B)
-        Tgc = B(elem)
-        dTgc = dB(elem)
-    end if
-end subroutine
-!===============================================================================
+        allocate(d2Tgc(nc), dTgc(nc), Tgc(nc))
+        call basis_bspline_2der(Xt, knot, nc, degree, d2Tgc, dTgc, Tgc)
+    end subroutine
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_d2Tgc_nurbs_1d_vector(Xt, knot, degree, nc, ng, Wc, d2Tgc, dTgc, Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_2der
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_dTgc_nurbs_1d_vector(Xt, knot, degree, nc, ng, Wc, dTgc, Tgc)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot(:)
+        integer, intent(in) :: degree
+        integer, intent(in) :: nc
+        integer, intent(in) :: ng
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable, intent(out) :: dTgc(:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:,:)
+        real(rk) :: dBi(nc), Bi(nc)
+        integer :: i
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot(:)
-    integer, intent(in) :: degree
-    integer, intent(in) :: nc
-    integer, intent(in) :: ng
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable, intent(out) :: d2Tgc(:,:)
-    real(rk), allocatable, intent(out) :: dTgc(:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:,:)
-    real(rk), allocatable :: d2Bi(:), dBi(:), Tgci(:), dTgci(:), Bi(:)
-    integer :: i
-
-    allocate(d2Tgc(ng, nc), dTgc(ng, nc), Tgc(ng, nc), d2Bi(nc), dTgci(nc), dBi(nc), Tgci(nc), Bi(nc))
-
-    do i = 1, size(Xt)
-        call basis_bspline_2der(Xt(i), knot, nc, degree, d2Bi, dBi, Bi)
-        Tgci = Bi*(Wc/(dot_product(Bi,Wc)))
-        Tgc(i,:) = Tgci
-
-        dTgci = ( dBi*Wc - Tgci*dot_product(dBi,Wc) ) / dot_product(Bi,Wc)
-        dTgc(i,:) = dTgci
-
-        d2Tgc(i,:) = (d2Bi*Wc - 2.0_rk*dTgci*dot_product(dBi,Wc) - Tgci*dot_product(d2Bi,Wc)) / dot_product(Bi,Wc)
-    end do
-end subroutine
-!===============================================================================
+        allocate(dTgc(ng, nc), Tgc(ng, nc))
+        do concurrent (i = 1: size(Xt))
+            call basis_bspline_der(Xt(i), knot, nc, degree, dBi, Bi)
+            Tgc(i,:) = Bi*(Wc/(dot_product(Bi,Wc)))
+            dTgc(i,:) = ( dBi*Wc - Tgc(i,:)*dot_product(dBi,Wc) ) / dot_product(Bi,Wc)
+        end do
+    end subroutine
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_d2Tgc_nurbs_1d_scalar(Xt, knot, degree, nc, Wc, d2Tgc, dTgc, Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_2der
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_dTgc_nurbs_1d_scalar(Xt, knot, degree, nc, Wc, dTgc, Tgc, elem)
+        real(rk), intent(in) :: Xt
+        real(rk), intent(in), contiguous :: knot(:)
+        integer, intent(in) :: degree
+        integer, intent(in) :: nc
+        real(rk), intent(in), contiguous :: Wc(:)
+        integer, intent(in), optional :: elem(:)
+        real(rk), allocatable, intent(out) :: dTgc(:)
+        real(rk), allocatable, intent(out) :: Tgc(:)
+        real(rk) :: dBi(nc), Bi(nc)
 
-    implicit none
-    real(rk), intent(in) :: Xt
-    real(rk), intent(in), contiguous :: knot(:)
-    integer, intent(in) :: degree
-    integer, intent(in) :: nc
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable, intent(out) :: d2Tgc(:)
-    real(rk), allocatable, intent(out) :: dTgc(:)
-    real(rk), allocatable, intent(out) :: Tgc(:)
-    real(rk), allocatable :: d2Bi(:), dBi(:), Bi(:)
+        call basis_bspline_der(Xt, knot, nc, degree, dBi, Bi)
 
-    allocate(d2Tgc(nc), dTgc(nc), Tgc(nc), d2Bi(nc), dBi(nc), Bi(nc))
-
-    call basis_bspline_2der(Xt, knot, nc, degree, d2Bi, dBi, Bi)
-    Tgc = Bi*(Wc/(dot_product(Bi,Wc)))
-    dTgc = ( dBi*Wc - Tgc*dot_product(dBi,Wc) ) / dot_product(Bi,Wc)
-    d2Tgc = (d2Bi*Wc - 2.0_rk*dTgc*dot_product(dBi,Wc) - Tgc*dot_product(d2Bi,Wc)) / dot_product(Bi,Wc)
-end subroutine
-!===============================================================================
-
-
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_d2Tgc_bspline_1d_vector(Xt, knot, degree, nc, ng, d2Tgc, dTgc, Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_2der
-
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot(:)
-    integer, intent(in) :: degree
-    integer, intent(in) :: nc
-    integer, intent(in) :: ng
-    real(rk), allocatable, intent(out) :: d2Tgc(:,:)
-    real(rk), allocatable, intent(out) :: dTgc(:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:,:)
-    real(rk), allocatable :: d2Tgci(:), dTgci(:), Tgci(:)
-    integer :: i
-
-    allocate(d2Tgc(ng, nc), dTgc(ng, nc), Tgc(ng, nc), dTgci(nc), Tgci(nc), d2Tgci(nc))
-    do i = 1, size(Xt)
-        call basis_bspline_2der(Xt(i), knot, nc, degree, d2Tgci, dTgci, Tgci)
-        Tgc(i,:) = Tgci
-        dTgc(i,:) = dTgci
-        d2Tgc(i,:) = d2Tgci
-    end do
-end subroutine
-!===============================================================================
+        if (.not. present(elem)) then
+            allocate(dTgc(nc), Tgc(nc))
+            Tgc = Bi*(Wc/(dot_product(Bi,Wc)))
+            dTgc = ( dBi*Wc - Tgc*dot_product(dBi,Wc) ) / dot_product(Bi,Wc)
+        else
+            allocate(dTgc(size(elem)), Tgc(size(elem)))
+            Tgc = Bi(elem)*(Wc(elem)/(dot_product(Bi(elem),Wc(elem))))
+            dTgc = ( dBi(elem)*Wc(elem) - Tgc*dot_product(dBi(elem),Wc(elem)) ) / dot_product(Bi(elem),Wc(elem))
+        end if
+    end subroutine
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_d2Tgc_bspline_1d_scalar(Xt, knot, degree, nc, d2Tgc, dTgc, Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_2der
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_dTgc_bspline_1d_vector(Xt, knot, degree, nc, ng, dTgc, Tgc)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot(:)
+        integer, intent(in) :: degree
+        integer, intent(in) :: nc
+        integer, intent(in) :: ng
+        real(rk), allocatable, intent(out) :: dTgc(:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:,:)
+        integer :: i
 
-    implicit none
-    real(rk), intent(in) :: Xt
-    real(rk), intent(in), contiguous :: knot(:)
-    integer, intent(in) :: degree
-    integer, intent(in) :: nc
-    real(rk), allocatable, intent(out) :: d2Tgc(:)
-    real(rk), allocatable, intent(out) :: dTgc(:)
-    real(rk), allocatable, intent(out) :: Tgc(:)
-
-    allocate(d2Tgc(nc), dTgc(nc), Tgc(nc))
-    call basis_bspline_2der(Xt, knot, nc, degree, d2Tgc, dTgc, Tgc)
-end subroutine
-!===============================================================================
-
-
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Tgc_nurbs_1d_vector(Xt, knot, degree, nc, ng, Wc) result(Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline
-
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot(:)
-    integer, intent(in) :: degree
-    integer, intent(in) :: nc
-    integer, intent(in) :: ng
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable :: Tgc(:,:)
-    real(rk), allocatable :: Tgci(:)
-    integer :: i
-
-    allocate(Tgc(ng, nc), Tgci(nc))
-    !$omp parallel do private(Tgci)
-    do i = 1, size(Xt,1)
-        Tgci = basis_bspline(Xt(i), knot, nc, degree)
-        Tgc(i,:) = Tgci*(Wc/(dot_product(Tgci,Wc)))
-    end do
-    !$omp end parallel do
-end function
-!===============================================================================
+        allocate(dTgc(ng, nc), Tgc(ng, nc))
+        do concurrent (i = 1: size(Xt))
+            call basis_bspline_der(Xt(i), knot, nc, degree, dTgc(i,:), Tgc(i,:))
+        end do
+    end subroutine
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Tgc_nurbs_1d_scalar(Xt, knot, degree, nc, Wc) result(Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_dTgc_bspline_1d_scalar(Xt, knot, degree, nc, dTgc, Tgc, elem)
+        real(rk), intent(in) :: Xt
+        real(rk), intent(in), contiguous :: knot(:)
+        integer, intent(in) :: degree
+        integer, intent(in) :: nc
+        integer, intent(in), optional :: elem(:)
+        real(rk), allocatable, intent(out) :: dTgc(:)
+        real(rk), allocatable, intent(out) :: Tgc(:)
+        real(rk), allocatable :: dB(:), B(:)
 
-    implicit none
-    real(rk), intent(in) :: Xt
-    real(rk), intent(in), contiguous :: knot(:)
-    integer, intent(in) :: degree
-    integer, intent(in) :: nc
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable :: Tgc(:)
-
-    allocate(Tgc(nc))
-    Tgc = basis_bspline(Xt, knot, nc, degree)
-    Tgc = Tgc*(Wc/(dot_product(Tgc,Wc)))
-end function
-!===============================================================================
-
-
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Tgc_bspline_1d_vector(Xt, knot, degree, nc, ng) result(Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline
-
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot(:)
-    integer, intent(in) :: degree
-    integer, intent(in) :: nc
-    integer, intent(in) :: ng
-    real(rk), allocatable :: Tgc(:,:)
-    integer :: i
-
-    allocate(Tgc(ng, nc))
-    !$omp parallel do
-    do i = 1, size(Xt,1)
-        Tgc(i,:) = basis_bspline(Xt(i), knot, nc, degree)
-    end do
-    !$omp end parallel do
-end function
-!===============================================================================
+        if (.not. present(elem)) then
+            allocate(dTgc(nc), Tgc(nc))
+            call basis_bspline_der(Xt, knot, nc, degree, dTgc, Tgc)
+        else
+            allocate(dB(size(elem)), B(size(elem)))
+            call basis_bspline_der(Xt, knot, nc, degree, dB, B)
+            Tgc = B(elem)
+            dTgc = dB(elem)
+        end if
+    end subroutine
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Tgc_bspline_1d_scalar(Xt, knot, degree, nc) result(Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Tgc_nurbs_1d_vector(Xt, knot, degree, nc, ng, Wc) result(Tgc)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot(:)
+        integer, intent(in) :: degree
+        integer, intent(in) :: nc
+        integer, intent(in) :: ng
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable :: Tgc(:,:)
+        real(rk), allocatable :: Tgci(:)
+        integer :: i
 
-    implicit none
-    real(rk), intent(in) :: Xt
-    real(rk), intent(in), contiguous :: knot(:)
-    integer, intent(in) :: degree
-    integer, intent(in) :: nc
-    real(rk), allocatable :: Tgc(:)
-
-    allocate(Tgc(nc))
-    Tgc = basis_bspline(Xt, knot, nc, degree)
-end function
-!===============================================================================
+        allocate(Tgc(ng, nc), Tgci(nc))
+        do concurrent (i = 1: size(Xt,1))
+            Tgci = basis_bspline(Xt(i), knot, nc, degree)
+            Tgc(i,:) = Tgci*(Wc/(dot_product(Tgci,Wc)))
+        end do
+    end function
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-pure function nearest_point_help_1d(ng, Xg, point_Xg) result(distances)
-    use forcad_kinds, only: rk
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Tgc_nurbs_1d_scalar(Xt, knot, degree, nc, Wc) result(Tgc)
+        real(rk), intent(in) :: Xt
+        real(rk), intent(in), contiguous :: knot(:)
+        integer, intent(in) :: degree
+        integer, intent(in) :: nc
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable :: Tgc(:)
 
-    implicit none
-    integer, intent(in) :: ng
-    real(rk), intent(in), contiguous :: Xg(:,:)
-    real(rk), intent(in), contiguous :: point_Xg(:)
-    real(rk), allocatable :: distances(:)
-    integer :: i
+        allocate(Tgc(nc))
+        Tgc = basis_bspline(Xt, knot, nc, degree)
+        Tgc = Tgc*(Wc/(dot_product(Tgc,Wc)))
+    end function
+    !===============================================================================
 
-    allocate(distances(ng))
-    do concurrent (i = 1: ng)
-        distances(i) = norm2(Xg(i,:) - point_Xg)
-    end do
-end function
-!===============================================================================
+
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Tgc_bspline_1d_vector(Xt, knot, degree, nc, ng) result(Tgc)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot(:)
+        integer, intent(in) :: degree
+        integer, intent(in) :: nc
+        integer, intent(in) :: ng
+        real(rk), allocatable :: Tgc(:,:)
+        integer :: i
+
+        allocate(Tgc(ng, nc))
+        do concurrent (i = 1: size(Xt,1))
+            Tgc(i,:) = basis_bspline(Xt(i), knot, nc, degree)
+        end do
+    end function
+    !===============================================================================
+
+
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Tgc_bspline_1d_scalar(Xt, knot, degree, nc) result(Tgc)
+        real(rk), intent(in) :: Xt
+        real(rk), intent(in), contiguous :: knot(:)
+        integer, intent(in) :: degree
+        integer, intent(in) :: nc
+        real(rk), allocatable :: Tgc(:)
+
+        allocate(Tgc(nc))
+        Tgc = basis_bspline(Xt, knot, nc, degree)
+    end function
+    !===============================================================================
+
+
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function nearest_point_help_1d(ng, Xg, point_Xg) result(distances)
+        integer, intent(in) :: ng
+        real(rk), intent(in), contiguous :: Xg(:,:)
+        real(rk), intent(in), contiguous :: point_Xg(:)
+        real(rk), allocatable :: distances(:)
+        integer :: i
+
+        allocate(distances(ng))
+        do concurrent (i = 1: ng)
+            distances(i) = norm2(Xg(i,:) - point_Xg)
+        end do
+    end function
+    !===============================================================================
+
+end module forcad_nurbs_curve

--- a/src/forcad_nurbs_surface.f90
+++ b/src/forcad_nurbs_surface.f90
@@ -1561,7 +1561,7 @@ contains
         integer, intent(in) :: dir
         real(rk), intent(in), contiguous :: Xth(:)
         integer, intent(in), contiguous :: r(:)
-        integer :: k, i, s, dim, j, n_new
+        integer :: k, i, s, d, j, n_new
         real(rk), allocatable :: Xc(:,:), Xcw(:,:), Xcw_new(:,:), Xc_new(:,:), Wc_new(:), knot_new(:)
         real(rk), allocatable:: Xc3(:,:,:)
 
@@ -1578,14 +1578,14 @@ contains
                         s = 0
                     end if
 
-                    dim = size(this%Xc,2)
-                    allocate(Xcw(size(this%Xc,1),dim+1))
+                    d = size(this%Xc,2)
+                    allocate(Xcw(size(this%Xc,1),d+1))
                     do j = 1, size(this%Xc,1)
-                        Xcw(j,1:dim) = this%Xc(j,1:dim)*this%Wc(j)
+                        Xcw(j,1:d) = this%Xc(j,1:d)*this%Wc(j)
                     end do
-                    Xcw(:,dim+1) = this%Wc(:)
+                    Xcw(:,d+1) = this%Wc(:)
 
-                    Xcw = reshape(Xcw,[this%nc(1),this%nc(2)*(dim+1)])
+                    Xcw = reshape(Xcw,[this%nc(1),this%nc(2)*(d+1)])
 
                     call insert_knot_A_5_1(&
                         this%degree(1),&
@@ -1599,14 +1599,14 @@ contains
                         knot_new,&
                         Xcw_new)
 
-                    Xcw_new = reshape(Xcw_new,[this%nc(2)*(n_new+1),dim+1])
+                    Xcw_new = reshape(Xcw_new,[this%nc(2)*(n_new+1),d+1])
 
-                    allocate(Xc_new(1:this%nc(2)*(n_new+1),1:dim))
+                    allocate(Xc_new(1:this%nc(2)*(n_new+1),1:d))
                     allocate(Wc_new(1:this%nc(2)*(n_new+1)))
                     do j = 1, this%nc(2)*(n_new+1)
-                        Xc_new(j,1:dim) = Xcw_new(j,1:dim)/Xcw_new(j,dim+1)
+                        Xc_new(j,1:d) = Xcw_new(j,1:d)/Xcw_new(j,d+1)
                     end do
-                    Wc_new(:) = Xcw_new(:,dim+1)
+                    Wc_new(:) = Xcw_new(:,d+1)
 
                     call this%set(knot1=knot_new, knot2=this%get_knot(2), Xc=Xc_new, Wc=Wc_new)
                     deallocate(Xcw, Xcw_new, Xc_new, Wc_new)
@@ -1623,9 +1623,9 @@ contains
                         s = 0
                     end if
 
-                    dim = size(this%Xc,2)
+                    d = size(this%Xc,2)
 
-                    Xc = reshape(this%Xc,[this%nc(1),this%nc(2)*dim])
+                    Xc = reshape(this%Xc,[this%nc(1),this%nc(2)*d])
 
                     call insert_knot_A_5_1(&
                         this%degree(1),&
@@ -1639,7 +1639,7 @@ contains
                         knot_new,&
                         Xc_new)
 
-                    Xc_new = reshape(Xc_new,[(this%nc(2))*(n_new+1),dim])
+                    Xc_new = reshape(Xc_new,[(this%nc(2))*(n_new+1),d])
 
                     call this%set(knot1=knot_new, knot2=this%get_knot(2), Xc=Xc_new)
                 end do
@@ -1659,16 +1659,16 @@ contains
                         s = 0
                     end if
 
-                    dim = size(this%Xc,2)
-                    allocate(Xcw(size(this%Xc,1),dim+1))
+                    d = size(this%Xc,2)
+                    allocate(Xcw(size(this%Xc,1),d+1))
                     do j = 1, size(this%Xc,1)
-                        Xcw(j,1:dim) = this%Xc(j,1:dim)*this%Wc(j)
+                        Xcw(j,1:d) = this%Xc(j,1:d)*this%Wc(j)
                     end do
-                    Xcw(:,dim+1) = this%Wc(:)
+                    Xcw(:,d+1) = this%Wc(:)
 
-                    Xc3 = reshape(Xcw, [this%nc(1),this%nc(2),dim+1])
-                    Xc3 = reshape(Xc3, [this%nc(2),this%nc(1),dim+1], order=[2,1,3])
-                    Xcw = reshape(Xc3,[this%nc(2),this%nc(1)*(dim+1)])
+                    Xc3 = reshape(Xcw, [this%nc(1),this%nc(2),d+1])
+                    Xc3 = reshape(Xc3, [this%nc(2),this%nc(1),d+1], order=[2,1,3])
+                    Xcw = reshape(Xc3,[this%nc(2),this%nc(1)*(d+1)])
 
                     call insert_knot_A_5_1(&
                         this%degree(2),&
@@ -1682,16 +1682,16 @@ contains
                         knot_new,&
                         Xcw_new)
 
-                    Xc3 = reshape(Xcw_new, [n_new+1,this%nc(1),dim+1])
-                    Xc3 = reshape(Xc3, [this%nc(1),n_new+1,dim+1], order=[2,1,3])
-                    Xcw_new = reshape(Xc3,[(this%nc(1))*(n_new+1),dim+1])
+                    Xc3 = reshape(Xcw_new, [n_new+1,this%nc(1),d+1])
+                    Xc3 = reshape(Xc3, [this%nc(1),n_new+1,d+1], order=[2,1,3])
+                    Xcw_new = reshape(Xc3,[(this%nc(1))*(n_new+1),d+1])
 
-                    allocate(Xc_new(1:(n_new+1)*this%nc(1),1:dim))
+                    allocate(Xc_new(1:(n_new+1)*this%nc(1),1:d))
                     allocate(Wc_new(1:(n_new+1)*this%nc(1)))
                     do j = 1, (n_new+1)*this%nc(1)
-                        Xc_new(j,1:dim) = Xcw_new(j,1:dim)/Xcw_new(j,dim+1)
+                        Xc_new(j,1:d) = Xcw_new(j,1:d)/Xcw_new(j,d+1)
                     end do
-                    Wc_new(:) = Xcw_new(:,dim+1)
+                    Wc_new(:) = Xcw_new(:,d+1)
 
                     call this%set(knot1=this%get_knot(1), knot2=knot_new, Xc=Xc_new, Wc=Wc_new)
                     deallocate(Xcw, Xcw_new, Xc_new, Wc_new)
@@ -1707,11 +1707,11 @@ contains
                         s = 0
                     end if
 
-                    dim = size(this%Xc,2)
+                    d = size(this%Xc,2)
 
-                    Xc3 = reshape(this%Xc, [this%nc(1),this%nc(2),dim])
-                    Xc3 = reshape(Xc3, [this%nc(2),this%nc(1),dim], order=[2,1,3])
-                    Xc = reshape(Xc3,[this%nc(2),this%nc(1)*dim])
+                    Xc3 = reshape(this%Xc, [this%nc(1),this%nc(2),d])
+                    Xc3 = reshape(Xc3, [this%nc(2),this%nc(1),d], order=[2,1,3])
+                    Xc = reshape(Xc3,[this%nc(2),this%nc(1)*d])
 
                     call insert_knot_A_5_1(&
                         this%degree(2),&
@@ -1725,9 +1725,9 @@ contains
                         knot_new,&
                         Xc_new)
 
-                    Xc3 = reshape(Xc_new, [n_new+1,this%nc(1),dim])
-                    Xc3 = reshape(Xc3, [this%nc(1),n_new+1,dim], order=[2,1,3])
-                    Xc_new = reshape(Xc3,[(this%nc(1))*(n_new+1),dim])
+                    Xc3 = reshape(Xc_new, [n_new+1,this%nc(1),d])
+                    Xc3 = reshape(Xc3, [this%nc(1),n_new+1,d], order=[2,1,3])
+                    Xc_new = reshape(Xc3,[(this%nc(1))*(n_new+1),d])
 
                     call this%set(knot1=this%get_knot(1), knot2=knot_new, Xc=Xc_new)
                 end do
@@ -1751,7 +1751,7 @@ contains
         integer, intent(in) :: dir
         integer, intent(in) :: t
         real(rk), allocatable :: Xc(:,:), Xcw(:,:), Xcw_new(:,:), knot_new(:), Xc_new(:,:), Wc_new(:)
-        integer :: dim, j, nc_new
+        integer :: d, j, nc_new
         real(rk), allocatable:: Xc3(:,:,:)
 
 
@@ -1759,38 +1759,38 @@ contains
 
             if(this%is_rational()) then ! NURBS
 
-                dim = size(this%Xc,2)
-                allocate(Xcw(size(this%Xc,1),dim+1))
+                d = size(this%Xc,2)
+                allocate(Xcw(size(this%Xc,1),d+1))
                 do j = 1, size(this%Xc,1)
-                    Xcw(j,1:dim) = this%Xc(j,1:dim)*this%Wc(j)
+                    Xcw(j,1:d) = this%Xc(j,1:d)*this%Wc(j)
                 end do
-                Xcw(:,dim+1) = this%Wc(:)
+                Xcw(:,d+1) = this%Wc(:)
 
-                Xcw = reshape(Xcw,[this%nc(1),this%nc(2)*(dim+1)],order=[1,2])
+                Xcw = reshape(Xcw,[this%nc(1),this%nc(2)*(d+1)],order=[1,2])
 
                 call elevate_degree_A_5_9(t, this%knot1, this%degree(1), Xcw, nc_new, knot_new, Xcw_new)
 
-                Xcw_new = reshape(Xcw_new,[this%nc(2)*nc_new,dim+1],order=[1,2])
+                Xcw_new = reshape(Xcw_new,[this%nc(2)*nc_new,d+1],order=[1,2])
 
-                allocate(Xc_new(1:this%nc(2)*nc_new,1:dim))
+                allocate(Xc_new(1:this%nc(2)*nc_new,1:d))
                 allocate(Wc_new(1:this%nc(2)*nc_new))
                 do j = 1, this%nc(2)*nc_new
-                    Xc_new(j,1:dim) = Xcw_new(j,1:dim)/Xcw_new(j,dim+1)
+                    Xc_new(j,1:d) = Xcw_new(j,1:d)/Xcw_new(j,d+1)
                 end do
 
-                Wc_new(:) = Xcw_new(:,dim+1)
+                Wc_new(:) = Xcw_new(:,d+1)
 
                 call this%set(knot1=knot_new, knot2=this%get_knot(2), Xc=Xc_new, Wc=Wc_new)
                 deallocate(Xcw, Xcw_new, Xc_new, Wc_new)
 
             else ! B-Spline
 
-                dim = size(this%Xc,2)
-                Xc = reshape(this%Xc,[this%nc(1),this%nc(2)*(dim)],order=[1,2])
+                d = size(this%Xc,2)
+                Xc = reshape(this%Xc,[this%nc(1),this%nc(2)*(d)],order=[1,2])
 
                 call elevate_degree_A_5_9(t, this%knot1, this%degree(1), Xc, nc_new, knot_new, Xc_new)
 
-                Xc_new = reshape(Xc_new,[this%nc(2)*nc_new,dim],order=[1,2])
+                Xc_new = reshape(Xc_new,[this%nc(2)*nc_new,d],order=[1,2])
 
                 call this%set(knot1=knot_new, knot2=this%get_knot(2), Xc=Xc_new)
                 deallocate(Xc, Xc_new)
@@ -1801,48 +1801,48 @@ contains
 
             if(this%is_rational()) then ! NURBS
 
-                dim = size(this%Xc,2)
-                allocate(Xcw(size(this%Xc,1),dim+1))
+                d = size(this%Xc,2)
+                allocate(Xcw(size(this%Xc,1),d+1))
                 do j = 1, size(this%Xc,1)
-                    Xcw(j,1:dim) = this%Xc(j,1:dim)*this%Wc(j)
+                    Xcw(j,1:d) = this%Xc(j,1:d)*this%Wc(j)
                 end do
 
-                Xcw(:,dim+1) = this%Wc(:)
+                Xcw(:,d+1) = this%Wc(:)
 
-                Xc3 = reshape(Xcw, [this%nc(1),this%nc(2),dim+1])
-                Xc3 = reshape(Xc3, [this%nc(2),this%nc(1),dim+1], order=[2,1,3])
-                Xcw = reshape(Xc3,[this%nc(2),this%nc(1)*(dim+1)])
+                Xc3 = reshape(Xcw, [this%nc(1),this%nc(2),d+1])
+                Xc3 = reshape(Xc3, [this%nc(2),this%nc(1),d+1], order=[2,1,3])
+                Xcw = reshape(Xc3,[this%nc(2),this%nc(1)*(d+1)])
 
                 call elevate_degree_A_5_9(t, this%knot2, this%degree(2), Xcw, nc_new, knot_new, Xcw_new)
 
-                Xc3 = reshape(Xcw_new, [nc_new,this%nc(1),dim+1])
-                Xc3 = reshape(Xc3, [this%nc(1),nc_new,dim+1], order=[2,1,3])
-                Xcw_new = reshape(Xc3,[(this%nc(1))*nc_new,dim+1])
+                Xc3 = reshape(Xcw_new, [nc_new,this%nc(1),d+1])
+                Xc3 = reshape(Xc3, [this%nc(1),nc_new,d+1], order=[2,1,3])
+                Xcw_new = reshape(Xc3,[(this%nc(1))*nc_new,d+1])
 
-                allocate(Xc_new(1:nc_new*this%nc(1),1:dim))
+                allocate(Xc_new(1:nc_new*this%nc(1),1:d))
                 allocate(Wc_new(1:nc_new*this%nc(1)))
                 do j = 1, nc_new*this%nc(1)
-                    Xc_new(j,1:dim) = Xcw_new(j,1:dim)/Xcw_new(j,dim+1)
+                    Xc_new(j,1:d) = Xcw_new(j,1:d)/Xcw_new(j,d+1)
                 end do
 
-                Wc_new(:) = Xcw_new(:,dim+1)
+                Wc_new(:) = Xcw_new(:,d+1)
 
                 call this%set(knot1=this%get_knot(1), knot2=knot_new, Xc=Xc_new, Wc=Wc_new)
                 deallocate(Xcw, Xcw_new, Xc_new, Wc_new)
 
             else ! B-Spline
 
-                dim = size(this%Xc,2)
+                d = size(this%Xc,2)
 
-                Xc3 = reshape(this%Xc, [this%nc(1),this%nc(2),dim])
-                Xc3 = reshape(Xc3, [this%nc(2),this%nc(1),dim], order=[2,1,3])
-                Xc = reshape(Xc3,[this%nc(2),this%nc(1)*dim])
+                Xc3 = reshape(this%Xc, [this%nc(1),this%nc(2),d])
+                Xc3 = reshape(Xc3, [this%nc(2),this%nc(1),d], order=[2,1,3])
+                Xc = reshape(Xc3,[this%nc(2),this%nc(1)*d])
 
                 call elevate_degree_A_5_9(t, this%knot2, this%degree(2), Xc, nc_new, knot_new, Xc_new)
 
-                Xc3 = reshape(Xc_new, [nc_new,this%nc(1),dim])
-                Xc3 = reshape(Xc3, [this%nc(1),nc_new,dim], order=[2,1,3])
-                Xc_new = reshape(Xc3,[(this%nc(1))*nc_new,dim])
+                Xc3 = reshape(Xc_new, [nc_new,this%nc(1),d])
+                Xc3 = reshape(Xc3, [this%nc(1),nc_new,d], order=[2,1,3])
+                Xc_new = reshape(Xc3,[(this%nc(1))*nc_new,d])
 
                 call this%set(knot1=this%get_knot(1), knot2=knot_new, Xc=Xc_new)
 
@@ -1956,7 +1956,7 @@ contains
         integer, intent(in) :: dir
         real(rk), intent(in), contiguous :: Xth(:)
         integer, intent(in), contiguous :: r(:)
-        integer :: k, i, s, dim, j, nc_new, t
+        integer :: k, i, s, d, j, nc_new, t
         real(rk), allocatable :: Xc(:,:), Xcw(:,:), Xcw_new(:,:), Xc_new(:,:), Wc_new(:), knot_new(:)
         real(rk), allocatable:: Xc3(:,:,:)
 
@@ -1974,14 +1974,14 @@ contains
                     end if
                     k = k + 1
 
-                    dim = size(this%Xc,2)
-                    allocate(Xcw(size(this%Xc,1),dim+1))
+                    d = size(this%Xc,2)
+                    allocate(Xcw(size(this%Xc,1),d+1))
                     do j = 1, size(this%Xc,1)
-                        Xcw(j,1:dim) = this%Xc(j,1:dim)*this%Wc(j)
+                        Xcw(j,1:d) = this%Xc(j,1:d)*this%Wc(j)
                     end do
-                    Xcw(:,dim+1) = this%Wc(:)
+                    Xcw(:,d+1) = this%Wc(:)
 
-                    Xcw = reshape(Xcw,[this%nc(1),this%nc(2)*(dim+1)],order=[1,2])
+                    Xcw = reshape(Xcw,[this%nc(1),this%nc(2)*(d+1)],order=[1,2])
 
                     call remove_knots_A_5_8(&
                         this%degree(1),&
@@ -2001,15 +2001,15 @@ contains
                         ! no change
                     else
                         nc_new = size(Xcw_new,1)
-                        Xcw_new = reshape(Xcw_new,[this%nc(2)*(nc_new),dim+1],order=[1,2])
+                        Xcw_new = reshape(Xcw_new,[this%nc(2)*(nc_new),d+1],order=[1,2])
 
-                        allocate(Xc_new(1:this%nc(2)*(nc_new),1:dim))
+                        allocate(Xc_new(1:this%nc(2)*(nc_new),1:d))
                         allocate(Wc_new(1:this%nc(2)*(nc_new)))
                         do j = 1, this%nc(2)*(nc_new)
-                            Xc_new(j,1:dim) = Xcw_new(j,1:dim)/Xcw_new(j,dim+1)
+                            Xc_new(j,1:d) = Xcw_new(j,1:d)/Xcw_new(j,d+1)
                         end do
 
-                        Wc_new(:) = Xcw_new(:,dim+1)
+                        Wc_new(:) = Xcw_new(:,d+1)
 
                         call this%set(knot1=knot_new, knot2=this%get_knot(2), Xc=Xc_new, Wc=Wc_new)
                         deallocate(Xcw_new, Xc_new, Wc_new)
@@ -2028,9 +2028,9 @@ contains
                     end if
                     k = k + 1
 
-                    dim = size(this%Xc,2)
+                    d = size(this%Xc,2)
 
-                    Xc = reshape(this%Xc,[this%nc(1),this%nc(2)*dim],order=[1,2])
+                    Xc = reshape(this%Xc,[this%nc(1),this%nc(2)*d],order=[1,2])
 
                     call remove_knots_A_5_8(&
                         this%degree(1),&
@@ -2050,7 +2050,7 @@ contains
                         ! no change
                     else
                         nc_new = size(Xc_new,1)
-                        Xc_new = reshape(Xc_new,[(this%nc(2))*(nc_new),dim],order=[1,2])
+                        Xc_new = reshape(Xc_new,[(this%nc(2))*(nc_new),d],order=[1,2])
 
                         call this%set(knot1=knot_new, knot2=this%get_knot(2), Xc=Xc_new)
                     end if
@@ -2072,17 +2072,17 @@ contains
                     end if
                     k = k + 1
 
-                    dim = size(this%Xc,2)
-                    allocate(Xcw(size(this%Xc,1),dim+1))
+                    d = size(this%Xc,2)
+                    allocate(Xcw(size(this%Xc,1),d+1))
                     do j = 1, size(this%Xc,1)
-                        Xcw(j,1:dim) = this%Xc(j,1:dim)*this%Wc(j)
+                        Xcw(j,1:d) = this%Xc(j,1:d)*this%Wc(j)
                     end do
 
-                    Xcw(:,dim+1) = this%Wc(:)
+                    Xcw(:,d+1) = this%Wc(:)
 
-                    Xc3 = reshape(Xcw, [this%nc(1),this%nc(2),dim+1])
-                    Xc3 = reshape(Xc3, [this%nc(2),this%nc(1),dim+1], order=[2,1,3])
-                    Xcw = reshape(Xc3, [this%nc(2),this%nc(1)*(dim+1)])
+                    Xc3 = reshape(Xcw, [this%nc(1),this%nc(2),d+1])
+                    Xc3 = reshape(Xc3, [this%nc(2),this%nc(1),d+1], order=[2,1,3])
+                    Xcw = reshape(Xc3, [this%nc(2),this%nc(1)*(d+1)])
 
                     call remove_knots_A_5_8(&
                         this%degree(2),&
@@ -2103,17 +2103,17 @@ contains
                     else
 
                         nc_new = size(Xcw_new,1)
-                        Xc3 = reshape(Xcw_new, [nc_new,this%nc(1),dim+1])
-                        Xc3 = reshape(Xc3, [this%nc(1),nc_new,dim+1], order=[2,1,3])
-                        Xcw_new = reshape(Xc3,[(this%nc(1))*(nc_new),dim+1])
+                        Xc3 = reshape(Xcw_new, [nc_new,this%nc(1),d+1])
+                        Xc3 = reshape(Xc3, [this%nc(1),nc_new,d+1], order=[2,1,3])
+                        Xcw_new = reshape(Xc3,[(this%nc(1))*(nc_new),d+1])
 
-                        allocate(Xc_new(1:(nc_new)*this%nc(1),1:dim))
+                        allocate(Xc_new(1:(nc_new)*this%nc(1),1:d))
                         allocate(Wc_new(1:(nc_new)*this%nc(1)))
                         do j = 1, (nc_new)*this%nc(1)
-                            Xc_new(j,1:dim) = Xcw_new(j,1:dim)/Xcw_new(j,dim+1)
+                            Xc_new(j,1:d) = Xcw_new(j,1:d)/Xcw_new(j,d+1)
                         end do
 
-                        Wc_new(:) = Xcw_new(:,dim+1)
+                        Wc_new(:) = Xcw_new(:,d+1)
 
                         call this%set(knot1=this%get_knot(1), knot2=knot_new, Xc=Xc_new, Wc=Wc_new)
                         deallocate(Xcw_new, Xc_new, Wc_new)
@@ -2132,11 +2132,11 @@ contains
                     end if
                     k = k + 1
 
-                    dim = size(this%Xc,2)
+                    d = size(this%Xc,2)
 
-                    Xc3 = reshape(this%Xc, [this%nc(1),this%nc(2),dim])
-                    Xc3 = reshape(Xc3, [this%nc(2),this%nc(1),dim], order=[2,1,3])
-                    Xc = reshape(Xc3,[this%nc(2),this%nc(1)*dim])
+                    Xc3 = reshape(this%Xc, [this%nc(1),this%nc(2),d])
+                    Xc3 = reshape(Xc3, [this%nc(2),this%nc(1),d], order=[2,1,3])
+                    Xc = reshape(Xc3,[this%nc(2),this%nc(1)*d])
 
                     call remove_knots_A_5_8(&
                         this%degree(2),&
@@ -2157,9 +2157,9 @@ contains
                     else
                         nc_new = size(Xc_new,1)
 
-                        Xc3 = reshape(Xc_new, [nc_new,this%nc(1),dim])
-                        Xc3 = reshape(Xc3, [this%nc(1),nc_new,dim], order=[2,1,3])
-                        Xc_new = reshape(Xc3,[(this%nc(1))*(nc_new),dim])
+                        Xc3 = reshape(Xc_new, [nc_new,this%nc(1),d])
+                        Xc3 = reshape(Xc3, [this%nc(1),nc_new,d], order=[2,1,3])
+                        Xc_new = reshape(Xc3,[(this%nc(1))*(nc_new),d])
 
                         call this%set(knot1=this%get_knot(1), knot2=knot_new, Xc=Xc_new)
                     end if

--- a/src/forcad_nurbs_surface.f90
+++ b/src/forcad_nurbs_surface.f90
@@ -2869,17 +2869,18 @@ contains
             d2Bi(1:nc(1)*nc(2)              ,2) = kron(dB2, dB1)
             d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),2) = kron(d2B2, B1)
 
-            d2Tgc(i,1:nc(1)*nc(2)              ,1) = &
-                (d2Bi(1:nc(1)*nc(2)              ,1)*Wc - 2.0_rk*dTgc(i,:,1)*dot_product(dBi(:,1),Wc)                                 &
-                - Tgc(i,:)*dot_product(d2Bi(1:nc(1)*nc(2)              ,1),Wc)) / dot_product(Bi,Wc)
+            d2Tgc(i,1:nc(1)*nc(2) ,1) = &
+                (d2Bi(1:nc(1)*nc(2) ,1)*Wc - 2.0_rk*dTgc(i,:,1)*dot_product(dBi(:,1),Wc) &
+                - Tgc(i,:)*dot_product(d2Bi(1:nc(1)*nc(2) ,1),Wc)) / dot_product(Bi,Wc)
             d2Tgc(i,nc(1)*nc(2)+1:2*nc(1)*nc(2),1) = &
-                (d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),1)*Wc - dTgc(i,:,1)*dot_product(dBi(:,2),Wc) - dTgc(i,:,2)*dot_product(dBi(:,1),Wc) &
+                (d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),1)*Wc &
+                - dTgc(i,:,1)*dot_product(dBi(:,2),Wc) - dTgc(i,:,2)*dot_product(dBi(:,1),Wc) &
                 - Tgc(i,:)*dot_product(d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),1),Wc)) / dot_product(Bi,Wc)
-            d2Tgc(i,1:nc(1)*nc(2)              ,2) = &
-                (d2Bi(1:nc(1)*nc(2)              ,2)*Wc - dTgc(i,:,1)*dot_product(dBi(:,2),Wc) - dTgc(i,:,2)*dot_product(dBi(:,1),Wc) &
-                - Tgc(i,:)*dot_product(d2Bi(1:nc(1)*nc(2)              ,2),Wc)) / dot_product(Bi,Wc)
+            d2Tgc(i,1:nc(1)*nc(2) ,2) = &
+                (d2Bi(1:nc(1)*nc(2) ,2)*Wc - dTgc(i,:,1)*dot_product(dBi(:,2),Wc) - dTgc(i,:,2)*dot_product(dBi(:,1),Wc) &
+                - Tgc(i,:)*dot_product(d2Bi(1:nc(1)*nc(2) ,2),Wc)) / dot_product(Bi,Wc)
             d2Tgc(i,nc(1)*nc(2)+1:2*nc(1)*nc(2),2) = &
-                (d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),2)*Wc - 2.0_rk*dTgc(i,:,2)*dot_product(dBi(:,2),Wc)                                 &
+                (d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),2)*Wc - 2.0_rk*dTgc(i,:,2)*dot_product(dBi(:,2),Wc) &
                 - Tgc(i,:)*dot_product(d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),2),Wc)) / dot_product(Bi,Wc)
         end do
     end subroutine

--- a/src/forcad_nurbs_surface.f90
+++ b/src/forcad_nurbs_surface.f90
@@ -6,7 +6,7 @@ module forcad_nurbs_surface
     use forcad_kinds, only: rk
     use forcad_utils, only: basis_bspline, elemConn_C0, kron, ndgrid, compute_multiplicity, compute_knot_vector, &
         basis_bspline_der, insert_knot_A_5_1, findspan, elevate_degree_A_5_9, remove_knots_A_5_8, tetragon_Xc, &
-        elemConn_Cn, unique, rotation, det, inv, gauss_leg, export_vtk_legacy
+        elemConn_Cn, unique, rotation, det, inv, gauss_leg, export_vtk_legacy, basis_bspline_2der
 
     implicit none
 
@@ -113,218 +113,31 @@ module forcad_nurbs_surface
     !===============================================================================
 
     interface compute_Xg
-        pure function compute_Xg_nurbs_2d(f_Xt, f_knot1, f_knot2, f_degree, f_nc, f_ng, f_Xc, f_Wc) result(f_Xg)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:,:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:)
-            integer, intent(in) :: f_degree(2)
-            integer, intent(in) :: f_nc(2)
-            integer, intent(in) :: f_ng(2)
-            real(rk), intent(in), contiguous :: f_Xc(:,:)
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable :: f_Xg(:,:)
-        end function
-
-        pure function compute_Xg_bspline_2d(f_Xt, f_knot1, f_knot2, f_degree, f_nc, f_ng, f_Xc) result(f_Xg)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:,:)
-            real(rk), intent(in), contiguous :: f_knot1(:)
-            real(rk), intent(in), contiguous :: f_knot2(:)
-            integer, intent(in) :: f_degree(2)
-            integer, intent(in) :: f_nc(2)
-            integer, intent(in) :: f_ng(2)
-            real(rk), intent(in), contiguous :: f_Xc(:,:)
-            real(rk), allocatable :: f_Xg(:,:)
-        end function
-
-        pure function compute_Xg_nurbs_2d_1point(f_Xt, f_knot1, f_knot2, f_degree, f_nc, f_Xc, f_Wc) result(f_Xg)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:)
-            integer, intent(in) :: f_degree(2)
-            integer, intent(in) :: f_nc(2)
-            real(rk), intent(in), contiguous :: f_Xc(:,:)
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable :: f_Xg(:)
-        end function
-
-        pure function compute_Xg_bspline_2d_1point(f_Xt, f_knot1, f_knot2, f_degree, f_nc, f_Xc) result(f_Xg)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot1(:)
-            real(rk), intent(in), contiguous :: f_knot2(:)
-            integer, intent(in) :: f_degree(2)
-            integer, intent(in) :: f_nc(2)
-            real(rk), intent(in), contiguous :: f_Xc(:,:)
-            real(rk), allocatable :: f_Xg(:)
-        end function
-    end interface
-
-    interface compute_dTgc
-        pure subroutine compute_dTgc_nurbs_2d_vector(f_Xt, f_knot1, f_knot2, f_degree, f_nc, f_ng, f_Wc, f_dTgc, f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:,:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:)
-            integer, intent(in) :: f_degree(2)
-            integer, intent(in) :: f_nc(2)
-            integer, intent(in) :: f_ng(2)
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:,:)
-        end subroutine
-
-        pure subroutine compute_dTgc_bspline_2d_vector(f_Xt, f_knot1, f_knot2, f_degree, nc, f_ng, f_dTgc, f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:,:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:)
-            integer, intent(in) :: f_degree(2)
-            integer, intent(in) :: nc(2)
-            integer, intent(in) :: f_ng(2)
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:,:)
-        end subroutine
-
-        pure subroutine compute_dTgc_nurbs_2d_scalar(f_Xt, f_knot1, f_knot2, f_degree, f_nc, f_Wc, f_dTgc, f_Tgc, elem)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:)
-            integer, intent(in) :: f_degree(2)
-            integer, intent(in) :: f_nc(2)
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:)
-            integer, intent(in) :: elem(:)
-        end subroutine
-
-        pure subroutine compute_dTgc_bspline_2d_scalar(f_Xt, f_knot1, f_knot2, f_degree, nc, f_dTgc, f_Tgc, elem)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:)
-            integer, intent(in) :: f_degree(2)
-            integer, intent(in) :: nc(2)
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:)
-            integer, intent(in) :: elem(:)
-        end subroutine
-    end interface
-
-    interface compute_d2Tgc
-        pure subroutine compute_d2Tgc_nurbs_2d_vector(f_Xt, f_knot1, f_knot2, f_degree, f_nc, f_ng, f_Wc, f_d2Tgc, f_dTgc, f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:,:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:)
-            integer, intent(in) :: f_degree(2)
-            integer, intent(in) :: f_nc(2)
-            integer, intent(in) :: f_ng(2)
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable, intent(out) :: f_d2Tgc(:,:,:)
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:,:)
-        end subroutine
-
-        pure subroutine compute_d2Tgc_bspline_2d_vector(f_Xt, f_knot1, f_knot2, f_degree, nc, f_ng, f_d2Tgc, f_dTgc, f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:,:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:)
-            integer, intent(in) :: f_degree(2)
-            integer, intent(in) :: nc(2)
-            integer, intent(in) :: f_ng(2)
-            real(rk), allocatable, intent(out) :: f_d2Tgc(:,:,:)
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:,:)
-        end subroutine
-
-        pure subroutine compute_d2Tgc_nurbs_2d_scalar(f_Xt, f_knot1, f_knot2, f_degree, f_nc, f_Wc, f_d2Tgc, f_dTgc, f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:)
-            integer, intent(in) :: f_degree(2)
-            integer, intent(in) :: f_nc(2)
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable, intent(out) :: f_d2Tgc(:,:)
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:)
-        end subroutine
-
-        pure subroutine compute_d2Tgc_bspline_2d_scalar(f_Xt, f_knot1, f_knot2, f_degree, nc, f_d2Tgc, f_dTgc, f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:)
-            integer, intent(in) :: f_degree(2)
-            integer, intent(in) :: nc(2)
-            real(rk), allocatable, intent(out) :: f_d2Tgc(:,:)
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:)
-        end subroutine
+        module procedure compute_Xg_nurbs_2d
+        module procedure compute_Xg_bspline_2d
+        module procedure compute_Xg_nurbs_2d_1point
+        module procedure compute_Xg_bspline_2d_1point
     end interface
 
     interface compute_Tgc
-        pure function compute_Tgc_nurbs_2d_vector(f_Xt, f_knot1, f_knot2, f_degree, f_nc, f_ng, f_Wc) result(f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:,:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:)
-            integer, intent(in) :: f_degree(2)
-            integer, intent(in) :: f_nc(2)
-            integer, intent(in) :: f_ng(2)
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable :: f_Tgc(:,:)
-        end function
-
-        pure function compute_Tgc_bspline_2d_vector(f_Xt, f_knot1, f_knot2, f_degree, f_nc, f_ng) result(f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:,:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:)
-            integer, intent(in) :: f_degree(2)
-            integer, intent(in) :: f_nc(2)
-            integer, intent(in) :: f_ng(2)
-            real(rk), allocatable :: f_Tgc(:,:)
-        end function
-
-        pure function compute_Tgc_nurbs_2d_scalar(f_Xt, f_knot1, f_knot2, f_degree, f_nc, f_Wc) result(f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:)
-            integer, intent(in) :: f_degree(2)
-            integer, intent(in) :: f_nc(2)
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable :: f_Tgc(:)
-        end function
-
-        pure function compute_Tgc_bspline_2d_scalar(f_Xt, f_knot1, f_knot2, f_degree, f_nc) result(f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:)
-            integer, intent(in) :: f_degree(2)
-            integer, intent(in) :: f_nc(2)
-            real(rk), allocatable :: f_Tgc(:)
-        end function
+        module procedure compute_Tgc_nurbs_2d_vector
+        module procedure compute_Tgc_bspline_2d_vector
+        module procedure compute_Tgc_nurbs_2d_scalar
+        module procedure compute_Tgc_bspline_2d_scalar
     end interface
 
-    interface
-        pure function nearest_point_help_2d(f_ng, f_Xg, f_point_Xg) result(f_distances)
-            import :: rk
-            implicit none
-            integer, intent(in) :: f_ng(2)
-            real(rk), intent(in), contiguous :: f_Xg(:,:)
-            real(rk), intent(in), contiguous :: f_point_Xg(:)
-            real(rk), allocatable :: f_distances(:)
-        end function
+    interface compute_dTgc
+        module procedure compute_dTgc_nurbs_2d_vector
+        module procedure compute_dTgc_bspline_2d_vector
+        module procedure compute_dTgc_nurbs_2d_scalar
+        module procedure compute_dTgc_bspline_2d_scalar
+    end interface
+
+    interface compute_d2Tgc
+        module procedure compute_d2Tgc_nurbs_2d_vector
+        module procedure compute_d2Tgc_bspline_2d_vector
+        module procedure compute_d2Tgc_nurbs_2d_scalar
+        module procedure compute_d2Tgc_bspline_2d_scalar
     end interface
 
 contains
@@ -2736,193 +2549,369 @@ contains
     end subroutine
     !===============================================================================
 
-end module forcad_nurbs_surface
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Xg_nurbs_2d(Xt, knot1, knot2, degree, nc, ng, Xc, Wc) result(Xg)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function cmp_Tgc_2d(Xti, knot1, knot2, nc, degree, Wc) result(Tgc)
+        real(rk), intent(in), contiguous :: Xti(:)
+        real(rk), intent(in), contiguous :: knot1(:)
+        real(rk), intent(in), contiguous :: knot2(:)
+        integer, intent(in) :: degree(2), nc(2)
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk) :: Tgc(nc(1)*nc(2))
+        real(rk) :: tmp
+        integer :: i
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:,:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:)
-    integer, intent(in) :: degree(2)
-    integer, intent(in) :: nc(2)
-    integer, intent(in) :: ng(2)
-    real(rk), intent(in), contiguous :: Xc(:,:)
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable :: Xg(:,:)
-    real(rk), allocatable :: Tgc(:)
-    integer :: i
-
-    allocate(Xg(ng(1)*ng(2), size(Xc,2)))
-    allocate(Tgc(nc(1)*nc(2)))
-
-    !$omp parallel do private(Tgc)
-    do i = 1, ng(1)*ng(2)
         Tgc = kron(&
-            basis_bspline(Xt(i,2), knot2, nc(2), degree(2)),&
-            basis_bspline(Xt(i,1), knot1, nc(1), degree(1)))
+            basis_bspline(Xti(2), knot2, nc(2), degree(2)),&
+            basis_bspline(Xti(1), knot1, nc(1), degree(1)))
+        tmp = dot_product(Tgc, Wc)
+        do concurrent (i = 1: nc(1)*nc(2))
+           Tgc(i) = (Tgc(i) * Wc(i)) / tmp
+        end do
+    end function
+    !===============================================================================
+
+
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Xg_nurbs_2d(Xt, knot1, knot2, degree, nc, ng, Xc, Wc) result(Xg)
+        real(rk), intent(in), contiguous :: Xt(:,:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:)
+        integer, intent(in) :: degree(2)
+        integer, intent(in) :: nc(2)
+        integer, intent(in) :: ng(2)
+        real(rk), intent(in), contiguous :: Xc(:,:)
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable :: Xg(:,:)
+        integer :: i
+
+        allocate(Xg(ng(1)*ng(2), size(Xc,2)))
+        do concurrent (i = 1: ng(1)*ng(2))
+            Xg(i,:) = matmul(cmp_Tgc_2d(Xt(i,:), knot1, knot2, nc, degree, Wc), Xc)
+        end do
+    end function
+    !===============================================================================
+
+
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Xg_nurbs_2d_1point(Xt, knot1, knot2, degree, nc, Xc, Wc) result(Xg)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:)
+        integer, intent(in) :: degree(2)
+        integer, intent(in) :: nc(2)
+        real(rk), intent(in), contiguous :: Xc(:,:)
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable :: Xg(:)
+        real(rk), allocatable :: Tgc(:)
+
+        allocate(Xg(size(Xc,2)))
+        allocate(Tgc(nc(1)*nc(2)))
+
+        Tgc = kron(&
+            basis_bspline(Xt(2), knot2, nc(2), degree(2)),&
+            basis_bspline(Xt(1), knot1, nc(1), degree(1)))
         Tgc = Tgc*(Wc/(dot_product(Tgc,Wc)))
-        Xg(i,:) = matmul(Tgc, Xc)
-    end do
-    !$omp end parallel do
-end function
-!===============================================================================
+        Xg= matmul(Tgc, Xc)
+    end function
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Xg_nurbs_2d_1point(Xt, knot1, knot2, degree, nc, Xc, Wc) result(Xg)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Xg_bspline_2d(Xt, knot1, knot2, degree, nc, ng, Xc) result(Xg)
+        real(rk), intent(in), contiguous :: Xt(:,:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:)
+        integer, intent(in) :: degree(2)
+        integer, intent(in) :: nc(2)
+        integer, intent(in) :: ng(2)
+        real(rk), intent(in), contiguous :: Xc(:,:)
+        real(rk), allocatable :: Xg(:,:)
+        integer :: i
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:)
-    integer, intent(in) :: degree(2)
-    integer, intent(in) :: nc(2)
-    real(rk), intent(in), contiguous :: Xc(:,:)
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable :: Xg(:)
-    real(rk), allocatable :: Tgc(:)
-
-    allocate(Xg(size(Xc,2)))
-    allocate(Tgc(nc(1)*nc(2)))
-
-    Tgc = kron(&
-        basis_bspline(Xt(2), knot2, nc(2), degree(2)),&
-        basis_bspline(Xt(1), knot1, nc(1), degree(1)))
-    Tgc = Tgc*(Wc/(dot_product(Tgc,Wc)))
-    Xg= matmul(Tgc, Xc)
-end function
-!===============================================================================
+        allocate(Xg(ng(1)*ng(2), size(Xc,2)))
+        do concurrent (i = 1: ng(1)*ng(2))
+            Xg(i,:) = matmul(kron(&
+                basis_bspline(Xt(i,2), knot2, nc(2), degree(2)),&
+                basis_bspline(Xt(i,1), knot1, nc(1), degree(1))),&
+                Xc)
+        end do
+    end function
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Xg_bspline_2d(Xt, knot1, knot2, degree, nc, ng, Xc) result(Xg)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Xg_bspline_2d_1point(Xt, knot1, knot2, degree, nc, Xc) result(Xg)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:)
+        integer, intent(in) :: degree(2)
+        integer, intent(in) :: nc(2)
+        real(rk), intent(in), contiguous :: Xc(:,:)
+        real(rk), allocatable :: Xg(:)
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:,:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:)
-    integer, intent(in) :: degree(2)
-    integer, intent(in) :: nc(2)
-    integer, intent(in) :: ng(2)
-    real(rk), intent(in), contiguous :: Xc(:,:)
-    real(rk), allocatable :: Xg(:,:)
-    integer :: i
-
-    allocate(Xg(ng(1)*ng(2), size(Xc,2)))
-    !$omp parallel do
-    do i = 1, ng(1)*ng(2)
-        Xg(i,:) = matmul(kron(&
-            basis_bspline(Xt(i,2), knot2, nc(2), degree(2)),&
-            basis_bspline(Xt(i,1), knot1, nc(1), degree(1))),&
+        allocate(Xg(size(Xc,2)))
+        Xg = matmul(kron(&
+            basis_bspline(Xt(2), knot2, nc(2), degree(2)),&
+            basis_bspline(Xt(1), knot1, nc(1), degree(1))),&
             Xc)
-    end do
-    !$omp end parallel do
-end function
-!===============================================================================
+    end function
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Xg_bspline_2d_1point(Xt, knot1, knot2, degree, nc, Xc) result(Xg)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_dTgc_nurbs_2d_vector(Xt, knot1, knot2, degree, nc, ng, Wc, dTgc, Tgc)
+        real(rk), intent(in), contiguous :: Xt(:,:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:)
+        integer, intent(in) :: degree(2)
+        integer, intent(in) :: nc(2)
+        integer, intent(in) :: ng(2)
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable, intent(out) :: dTgc(:,:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:,:)
+        real(rk) :: dB1(nc(1)), dB2(nc(2))
+        real(rk) :: B1(nc(1)), B2(nc(2))
+        real(rk), allocatable :: dBi(:,:), Bi(:)
+        integer :: i
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:)
-    integer, intent(in) :: degree(2)
-    integer, intent(in) :: nc(2)
-    real(rk), intent(in), contiguous :: Xc(:,:)
-    real(rk), allocatable :: Xg(:)
+        allocate(dTgc(ng(1)*ng(2), nc(1)*nc(2), 2), Tgc(ng(1)*ng(2), nc(1)*nc(2)))
+        allocate(Bi(nc(1)*nc(2)), dBi(nc(1)*nc(2), 2))
+        do concurrent (i = 1: size(Xt, 1))
+            call basis_bspline_der(Xt(i,1), knot1, nc(1), degree(1), dB1, B1)
+            call basis_bspline_der(Xt(i,2), knot2, nc(2), degree(2), dB2, B2)
 
-    allocate(Xg(size(Xc,2)))
-    Xg= matmul(kron(&
-        basis_bspline(Xt(2), knot2, nc(2), degree(2)),&
-        basis_bspline(Xt(1), knot1, nc(1), degree(1))),&
-        Xc)
-end function
-!===============================================================================
+            Bi = kron(B2, B1)
+
+            Tgc(i,:) = Bi*(Wc/(dot_product(Bi,Wc)))
+
+            dBi(:,1) = kron(B2, dB1)
+            dBi(:,2) = kron(dB2, B1)
+
+            dTgc(i,:,1) = ( dBi(:,1)*Wc - Tgc(i,:)*dot_product(dBi(:,1),Wc) ) / dot_product(Bi,Wc)
+            dTgc(i,:,2) = ( dBi(:,2)*Wc - Tgc(i,:)*dot_product(dBi(:,2),Wc) ) / dot_product(Bi,Wc)
+        end do
+    end subroutine
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_dTgc_nurbs_2d_vector(Xt, knot1, knot2, degree, nc, ng, Wc, dTgc, Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_der, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_dTgc_nurbs_2d_scalar(Xt, knot1, knot2, degree, nc, Wc, dTgc, Tgc, elem)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:)
+        integer, intent(in) :: degree(2)
+        integer, intent(in) :: nc(2)
+        real(rk), intent(in), contiguous :: Wc(:)
+        integer, intent(in), optional :: elem(:)
+        real(rk), allocatable, intent(out) :: dTgc(:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:)
+        real(rk) :: dB1(nc(1)), dB2(nc(2))
+        real(rk) :: B1(nc(1)), B2(nc(2))
+        real(rk), allocatable :: dBi(:,:), Bi(:)
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:,:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:)
-    integer, intent(in) :: degree(2)
-    integer, intent(in) :: nc(2)
-    integer, intent(in) :: ng(2)
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable, intent(out) :: dTgc(:,:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:,:)
-    real(rk), allocatable :: dBi(:,:), dB1(:), dB2(:)
-    real(rk), allocatable :: Bi(:), B1(:), B2(:)
-    integer :: i
 
-    allocate(dTgc(ng(1)*ng(2), nc(1)*nc(2), 2), Tgc(ng(1)*ng(2), nc(1)*nc(2)))
-    allocate(Bi(nc(1)*nc(2)), dBi(nc(1)*nc(2), 2))
-    do i = 1, size(Xt, 1)
-        call basis_bspline_der(Xt(i,1), knot1, nc(1), degree(1), dB1, B1)
-        call basis_bspline_der(Xt(i,2), knot2, nc(2), degree(2), dB2, B2)
+        call basis_bspline_der(Xt(1), knot1, nc(1), degree(1), dB1, B1)
+        call basis_bspline_der(Xt(2), knot2, nc(2), degree(2), dB2, B2)
+
+        if (.not. present(elem)) then
+            allocate(dTgc(nc(1)*nc(2), 2), Tgc(nc(1)*nc(2)))
+            allocate(dBi(nc(1)*nc(2), 2), Bi(nc(1)*nc(2)))
+
+            Bi = kron(B2, B1)
+            Tgc = Bi*(Wc/(dot_product(Bi,Wc)))
+
+            dBi(:,1) = kron(B2, dB1)
+            dBi(:,2) = kron(dB2, B1)
+
+            dTgc(:,1) = ( dBi(:,1)*Wc - Tgc*dot_product(dBi(:,1),Wc) ) / dot_product(Bi,Wc)
+            dTgc(:,2) = ( dBi(:,2)*Wc - Tgc*dot_product(dBi(:,2),Wc) ) / dot_product(Bi,Wc)
+        else
+            allocate(dTgc(size(elem), 2), Tgc(size(elem)))
+            allocate(dBi(size(elem), 2), Bi(size(elem)))
+
+            associate(Biall => kron(B2, B1))
+                Bi = Biall(elem)
+                Tgc = Bi*(Wc(elem)/(dot_product(Bi,Wc(elem))))
+            end associate
+
+            associate(dB1all => kron(B2, dB1), dB2all => kron(dB2, B1))
+                dBi(:,1) = dB1all(elem)
+                dBi(:,2) = dB2all(elem)
+            end associate
+
+            dTgc(:,1) = ( dBi(:,1)*Wc(elem) - Tgc*dot_product(dBi(:,1),Wc(elem)) ) / dot_product(Bi,Wc(elem))
+            dTgc(:,2) = ( dBi(:,2)*Wc(elem) - Tgc*dot_product(dBi(:,2),Wc(elem)) ) / dot_product(Bi,Wc(elem))
+        end if
+    end subroutine
+    !===============================================================================
+
+
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_dTgc_bspline_2d_vector(Xt, knot1, knot2, degree, nc, ng, dTgc, Tgc)
+        real(rk), intent(in), contiguous :: Xt(:,:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:)
+        integer, intent(in) :: degree(2)
+        integer, intent(in) :: nc(2)
+        integer, intent(in) :: ng(2)
+        real(rk), allocatable, intent(out) :: dTgc(:,:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:,:)
+        real(rk) :: dB1(nc(1)), dB2(nc(2))
+        real(rk) :: B1(nc(1)), B2(nc(2))
+        integer :: i
+
+        allocate(dTgc(ng(1)*ng(2), nc(1)*nc(2), 2), Tgc(ng(1)*ng(2), nc(1)*nc(2)))
+
+        do concurrent (i = 1: size(Xt, 1))
+            call basis_bspline_der(Xt(i,1), knot1, nc(1), degree(1), dB1, B1)
+            call basis_bspline_der(Xt(i,2), knot2, nc(2), degree(2), dB2, B2)
+            Tgc(i,:) = kron(B2, B1)
+
+            dTgc(i,:,1) = kron(B2, dB1)
+            dTgc(i,:,2) = kron(dB2, B1)
+        end do
+    end subroutine
+    !===============================================================================
+
+
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_dTgc_bspline_2d_scalar(Xt, knot1, knot2, degree, nc, dTgc, Tgc, elem)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:)
+        integer, intent(in) :: degree(2)
+        integer, intent(in) :: nc(2)
+        integer, intent(in), optional :: elem(:)
+        real(rk), allocatable, intent(out) :: dTgc(:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:)
+        real(rk) :: dTgc1(nc(1)), dTgc2(nc(2))
+        real(rk) :: Tgc1(nc(1)), Tgc2(nc(2))
+
+        call basis_bspline_der(Xt(1), knot1, nc(1), degree(1), dTgc1, Tgc1)
+        call basis_bspline_der(Xt(2), knot2, nc(2), degree(2), dTgc2, Tgc2)
+
+        if (.not. present(elem)) then
+            allocate(dTgc(nc(1)*nc(2), 2))
+            Tgc = kron(Tgc2, Tgc1)
+
+            dTgc(:,1) = kron(Tgc2, dTgc1)
+            dTgc(:,2) = kron(dTgc2, Tgc1)
+        else
+            allocate(dTgc(size(elem), 2))
+
+            associate(B => kron(Tgc2, Tgc1))
+                Tgc = B(elem)
+            end associate
+
+            associate(dB1 => kron(Tgc2, dTgc1), dB2 => kron(dTgc2, Tgc1))
+                dTgc(:,1) = dB1(elem)
+                dTgc(:,2) = dB2(elem)
+            end associate
+        end if
+    end subroutine
+    !===============================================================================
+
+
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_d2Tgc_nurbs_2d_vector(Xt, knot1, knot2, degree, nc, ng, Wc, d2Tgc, dTgc, Tgc)
+        real(rk), intent(in), contiguous :: Xt(:,:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:)
+        integer, intent(in) :: degree(2)
+        integer, intent(in) :: nc(2)
+        integer, intent(in) :: ng(2)
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable, intent(out) :: d2Tgc(:,:,:)
+        real(rk), allocatable, intent(out) :: dTgc(:,:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:,:)
+        real(rk) :: d2B1(nc(1)), d2B2(nc(2))
+        real(rk) :: dB1(nc(1)), dB2(nc(2))
+        real(rk) :: B1(nc(1)), B2(nc(2))
+        real(rk), allocatable :: Tgci(:), dTgci(:)
+        real(rk), allocatable :: d2Bi(:,:), dBi(:,:), Bi(:)
+
+        integer :: i
+
+        allocate(d2Tgc(ng(1)*ng(2), 2*nc(1)*nc(2), 2))
+
+        allocate(Bi(nc(1)*nc(2)), dBi(nc(1)*nc(2), 2), d2Bi(2*nc(1)*nc(2), 2))
+
+        allocate(Tgci(nc(1)*nc(2)), dTgci(nc(1)*nc(2)))
+        allocate(Tgc(ng(1)*ng(2), nc(1)*nc(2)), dTgc(ng(1)*ng(2), nc(1)*nc(2), 2))
+        do concurrent (i = 1: size(Xt, 1))
+            call basis_bspline_2der(Xt(i,1), knot1, nc(1), degree(1), d2B1, dB1, B1)
+            call basis_bspline_2der(Xt(i,2), knot2, nc(2), degree(2), d2B2, dB2, B2)
+
+            Bi = kron(B2, B1)
+
+            Tgc(i,:) = Bi*(Wc/(dot_product(Bi,Wc)))
+
+            dBi(:,1) = kron(B2, dB1)
+            dBi(:,2) = kron(dB2, B1)
+
+            dTgc(i,:,1) = ( dBi(:,1)*Wc - Tgc(i,:)*dot_product(dBi(:,1),Wc) ) / dot_product(Bi,Wc)
+            dTgc(i,:,2) = ( dBi(:,2)*Wc - Tgc(i,:)*dot_product(dBi(:,2),Wc) ) / dot_product(Bi,Wc)
+
+            d2Bi(1:nc(1)*nc(2)              ,1) = kron(B2, d2B1)
+            d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),1) = kron(dB2, dB1)
+            d2Bi(1:nc(1)*nc(2)              ,2) = kron(dB2, dB1)
+            d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),2) = kron(d2B2, B1)
+
+            d2Tgc(i,1:nc(1)*nc(2)              ,1) = &
+                (d2Bi(1:nc(1)*nc(2)              ,1)*Wc - 2.0_rk*dTgc(i,:,1)*dot_product(dBi(:,1),Wc)                                 &
+                - Tgc(i,:)*dot_product(d2Bi(1:nc(1)*nc(2)              ,1),Wc)) / dot_product(Bi,Wc)
+            d2Tgc(i,nc(1)*nc(2)+1:2*nc(1)*nc(2),1) = &
+                (d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),1)*Wc - dTgc(i,:,1)*dot_product(dBi(:,2),Wc) - dTgc(i,:,2)*dot_product(dBi(:,1),Wc) &
+                - Tgc(i,:)*dot_product(d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),1),Wc)) / dot_product(Bi,Wc)
+            d2Tgc(i,1:nc(1)*nc(2)              ,2) = &
+                (d2Bi(1:nc(1)*nc(2)              ,2)*Wc - dTgc(i,:,1)*dot_product(dBi(:,2),Wc) - dTgc(i,:,2)*dot_product(dBi(:,1),Wc) &
+                - Tgc(i,:)*dot_product(d2Bi(1:nc(1)*nc(2)              ,2),Wc)) / dot_product(Bi,Wc)
+            d2Tgc(i,nc(1)*nc(2)+1:2*nc(1)*nc(2),2) = &
+                (d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),2)*Wc - 2.0_rk*dTgc(i,:,2)*dot_product(dBi(:,2),Wc)                                 &
+                - Tgc(i,:)*dot_product(d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),2),Wc)) / dot_product(Bi,Wc)
+        end do
+    end subroutine
+    !===============================================================================
+
+
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_d2Tgc_nurbs_2d_scalar(Xt, knot1, knot2, degree, nc, Wc, d2Tgc, dTgc, Tgc)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:)
+        integer, intent(in) :: degree(2)
+        integer, intent(in) :: nc(2)
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable, intent(out) :: d2Tgc(:,:)
+        real(rk), allocatable, intent(out) :: dTgc(:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:)
+        real(rk) :: d2B1(nc(1)), d2B2(nc(2))
+        real(rk) :: dB1(nc(1)), dB2(nc(2))
+        real(rk) :: B1(nc(1)), B2(nc(2))
+        real(rk), allocatable :: d2Bi(:,:), dBi(:,:), Bi(:)
+
+        allocate(Bi(nc(1)*nc(2)), dBi(nc(1)*nc(2), 2), d2Bi(2*nc(1)*nc(2), 2))
+
+        allocate(Tgc(nc(1)*nc(2)), dTgc(nc(1)*nc(2), 2), d2Tgc(2*nc(1)*nc(2), 2))
+
+        call basis_bspline_2der(Xt(1), knot1, nc(1), degree(1), d2B1, dB1, B1)
+        call basis_bspline_2der(Xt(2), knot2, nc(2), degree(2), d2B2, dB2, B2)
 
         Bi = kron(B2, B1)
 
-        Tgc(i,:) = Bi*(Wc/(dot_product(Bi,Wc)))
-
-        dBi(:,1) = kron(B2, dB1)
-        dBi(:,2) = kron(dB2, B1)
-
-        dTgc(i,:,1) = ( dBi(:,1)*Wc - Tgc(i,:)*dot_product(dBi(:,1),Wc) ) / dot_product(Bi,Wc)
-        dTgc(i,:,2) = ( dBi(:,2)*Wc - Tgc(i,:)*dot_product(dBi(:,2),Wc) ) / dot_product(Bi,Wc)
-    end do
-end subroutine
-!===============================================================================
-
-
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_dTgc_nurbs_2d_scalar(Xt, knot1, knot2, degree, nc, Wc, dTgc, Tgc, elem)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_der, kron
-
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:)
-    integer, intent(in) :: degree(2)
-    integer, intent(in) :: nc(2)
-    real(rk), intent(in), contiguous :: Wc(:)
-    integer, intent(in), optional :: elem(:)
-    real(rk), allocatable, intent(out) :: dTgc(:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:)
-    real(rk), allocatable :: dB1(:), dB2(:), dBi(:,:)
-    real(rk), allocatable :: B1(:), B2(:), Bi(:)
-
-    call basis_bspline_der(Xt(1), knot1, nc(1), degree(1), dB1, B1)
-    call basis_bspline_der(Xt(2), knot2, nc(2), degree(2), dB2, B2)
-
-    if (.not. present(elem)) then
-        allocate(dTgc(nc(1)*nc(2), 2), Tgc(nc(1)*nc(2)))
-        allocate(dBi(nc(1)*nc(2), 2), Bi(nc(1)*nc(2)))
-
-        Bi = kron(B2, B1)
         Tgc = Bi*(Wc/(dot_product(Bi,Wc)))
 
         dBi(:,1) = kron(B2, dB1)
@@ -2930,435 +2919,200 @@ impure subroutine compute_dTgc_nurbs_2d_scalar(Xt, knot1, knot2, degree, nc, Wc,
 
         dTgc(:,1) = ( dBi(:,1)*Wc - Tgc*dot_product(dBi(:,1),Wc) ) / dot_product(Bi,Wc)
         dTgc(:,2) = ( dBi(:,2)*Wc - Tgc*dot_product(dBi(:,2),Wc) ) / dot_product(Bi,Wc)
-    else
-        allocate(dTgc(size(elem), 2), Tgc(size(elem)))
-        allocate(dBi(size(elem), 2), Bi(size(elem)))
-
-        associate(Biall => kron(B2, B1))
-            Bi = Biall(elem)
-            Tgc = Bi*(Wc(elem)/(dot_product(Bi,Wc(elem))))
-        end associate
-
-        associate(dB1all => kron(B2, dB1), dB2all => kron(dB2, B1))
-            dBi(:,1) = dB1all(elem)
-            dBi(:,2) = dB2all(elem)
-        end associate
-
-        dTgc(:,1) = ( dBi(:,1)*Wc(elem) - Tgc*dot_product(dBi(:,1),Wc(elem)) ) / dot_product(Bi,Wc(elem))
-        dTgc(:,2) = ( dBi(:,2)*Wc(elem) - Tgc*dot_product(dBi(:,2),Wc(elem)) ) / dot_product(Bi,Wc(elem))
-    end if
-end subroutine
-!===============================================================================
-
-
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_dTgc_bspline_2d_vector(Xt, knot1, knot2, degree, nc, ng, dTgc, Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_der, kron
-
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:,:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:)
-    integer, intent(in) :: degree(2)
-    integer, intent(in) :: nc(2)
-    integer, intent(in) :: ng(2)
-    real(rk), allocatable, intent(out) :: dTgc(:,:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:,:)
-    real(rk), allocatable :: dB1(:), dB2(:)
-    real(rk), allocatable :: B1(:), B2(:)
-    integer :: i
-
-    allocate(dTgc(ng(1)*ng(2), nc(1)*nc(2), 2), Tgc(ng(1)*ng(2), nc(1)*nc(2)))
-    allocate(B1(nc(1)), B2(nc(2)), dB1(nc(1)), dB2(nc(2)))
-
-    do i = 1, size(Xt, 1)
-        call basis_bspline_der(Xt(i,1), knot1, nc(1), degree(1), dB1, B1)
-        call basis_bspline_der(Xt(i,2), knot2, nc(2), degree(2), dB2, B2)
-        Tgc(i,:) = kron(B2, B1)
-
-        dTgc(i,:,1) = kron(B2, dB1)
-        dTgc(i,:,2) = kron(dB2, B1)
-    end do
-end subroutine
-!===============================================================================
-
-
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_dTgc_bspline_2d_scalar(Xt, knot1, knot2, degree, nc, dTgc, Tgc, elem)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_der, kron
-
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:)
-    integer, intent(in) :: degree(2)
-    integer, intent(in) :: nc(2)
-    integer, intent(in), optional :: elem(:)
-    real(rk), allocatable, intent(out) :: dTgc(:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:)
-    real(rk), allocatable :: dTgc1(:), dTgc2(:)
-    real(rk), allocatable :: Tgc1(:), Tgc2(:)
-
-    call basis_bspline_der(Xt(1), knot1, nc(1), degree(1), dTgc1, Tgc1)
-    call basis_bspline_der(Xt(2), knot2, nc(2), degree(2), dTgc2, Tgc2)
-
-    if (.not. present(elem)) then
-        allocate(dTgc(nc(1)*nc(2), 2))
-        Tgc = kron(Tgc2, Tgc1)
-
-        dTgc(:,1) = kron(Tgc2, dTgc1)
-        dTgc(:,2) = kron(dTgc2, Tgc1)
-    else
-        allocate(dTgc(size(elem), 2))
-
-        associate(B => kron(Tgc2, Tgc1))
-            Tgc = B(elem)
-        end associate
-
-        associate(dB1 => kron(Tgc2, dTgc1), dB2 => kron(dTgc2, Tgc1))
-            dTgc(:,1) = dB1(elem)
-            dTgc(:,2) = dB2(elem)
-        end associate
-    end if
-end subroutine
-!===============================================================================
-
-
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_d2Tgc_nurbs_2d_vector(Xt, knot1, knot2, degree, nc, ng, Wc, d2Tgc, dTgc, Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_2der, kron
-
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:,:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:)
-    integer, intent(in) :: degree(2)
-    integer, intent(in) :: nc(2)
-    integer, intent(in) :: ng(2)
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable, intent(out) :: d2Tgc(:,:,:)
-    real(rk), allocatable, intent(out) :: dTgc(:,:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:,:)
-    real(rk), allocatable :: d2Bi(:,:), d2B1(:), d2B2(:)
-    real(rk), allocatable :: dBi(:,:), dB1(:), dB2(:)
-    real(rk), allocatable :: Bi(:), B1(:), B2(:)
-    real(rk), allocatable :: Tgci(:), dTgci(:)
-
-    integer :: i
-
-    allocate(d2Tgc(ng(1)*ng(2), 2*nc(1)*nc(2), 2))
-
-    allocate(B1(nc(1)), B2(nc(2)))
-    allocate(dB1(nc(1)), dB2(nc(2)))
-    allocate(d2B1(nc(1)), d2B2(nc(2)))
-    allocate(Bi(nc(1)*nc(2)), dBi(nc(1)*nc(2), 2), d2Bi(2*nc(1)*nc(2), 2))
-
-    allocate(Tgci(nc(1)*nc(2)), dTgci(nc(1)*nc(2)))
-    allocate(Tgc(ng(1)*ng(2), nc(1)*nc(2)), dTgc(ng(1)*ng(2), nc(1)*nc(2), 2))
-    do i = 1, size(Xt, 1)
-        call basis_bspline_2der(Xt(i,1), knot1, nc(1), degree(1), d2B1, dB1, B1)
-        call basis_bspline_2der(Xt(i,2), knot2, nc(2), degree(2), d2B2, dB2, B2)
-
-        Bi = kron(B2, B1)
-
-        Tgc(i,:) = Bi*(Wc/(dot_product(Bi,Wc)))
-
-        dBi(:,1) = kron(B2, dB1)
-        dBi(:,2) = kron(dB2, B1)
-
-        dTgc(i,:,1) = ( dBi(:,1)*Wc - Tgc(i,:)*dot_product(dBi(:,1),Wc) ) / dot_product(Bi,Wc)
-        dTgc(i,:,2) = ( dBi(:,2)*Wc - Tgc(i,:)*dot_product(dBi(:,2),Wc) ) / dot_product(Bi,Wc)
 
         d2Bi(1:nc(1)*nc(2)              ,1) = kron(B2, d2B1)
         d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),1) = kron(dB2, dB1)
         d2Bi(1:nc(1)*nc(2)              ,2) = kron(dB2, dB1)
         d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),2) = kron(d2B2, B1)
 
-        d2Tgc(i,1:nc(1)*nc(2)              ,1) = &
-            (d2Bi(1:nc(1)*nc(2)              ,1)*Wc - 2.0_rk*dTgc(i,:,1)*dot_product(dBi(:,1),Wc)                                 &
-            - Tgc(i,:)*dot_product(d2Bi(1:nc(1)*nc(2)              ,1),Wc)) / dot_product(Bi,Wc)
-        d2Tgc(i,nc(1)*nc(2)+1:2*nc(1)*nc(2),1) = &
-            (d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),1)*Wc - dTgc(i,:,1)*dot_product(dBi(:,2),Wc) - dTgc(i,:,2)*dot_product(dBi(:,1),Wc) &
-            - Tgc(i,:)*dot_product(d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),1),Wc)) / dot_product(Bi,Wc)
-        d2Tgc(i,1:nc(1)*nc(2)              ,2) = &
-            (d2Bi(1:nc(1)*nc(2)              ,2)*Wc - dTgc(i,:,1)*dot_product(dBi(:,2),Wc) - dTgc(i,:,2)*dot_product(dBi(:,1),Wc) &
-            - Tgc(i,:)*dot_product(d2Bi(1:nc(1)*nc(2)              ,2),Wc)) / dot_product(Bi,Wc)
-        d2Tgc(i,nc(1)*nc(2)+1:2*nc(1)*nc(2),2) = &
-            (d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),2)*Wc - 2.0_rk*dTgc(i,:,2)*dot_product(dBi(:,2),Wc)                                 &
-            - Tgc(i,:)*dot_product(d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),2),Wc)) / dot_product(Bi,Wc)
-    end do
-end subroutine
-!===============================================================================
+        d2Tgc(1:nc(1)*nc(2)              ,1) = &
+            (d2Bi(1:nc(1)*nc(2)              ,1)*Wc - 2.0_rk*dTgc(:,1)*dot_product(dBi(:,1),Wc)                               &
+            - Tgc*dot_product(d2Bi(1:nc(1)*nc(2)              ,1),Wc)) / dot_product(Bi,Wc)
+        d2Tgc(nc(1)*nc(2)+1:2*nc(1)*nc(2),1) = &
+            (d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),1)*Wc - dTgc(:,1)*dot_product(dBi(:,2),Wc) - dTgc(:,2)*dot_product(dBi(:,1),Wc) &
+            - Tgc*dot_product(d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),1),Wc)) / dot_product(Bi,Wc)
+        d2Tgc(1:nc(1)*nc(2)              ,2) = &
+            (d2Bi(1:nc(1)*nc(2)              ,2)*Wc - dTgc(:,1)*dot_product(dBi(:,2),Wc) - dTgc(:,2)*dot_product(dBi(:,1),Wc) &
+            - Tgc*dot_product(d2Bi(1:nc(1)*nc(2)              ,2),Wc)) / dot_product(Bi,Wc)
+        d2Tgc(nc(1)*nc(2)+1:2*nc(1)*nc(2),2) = &
+            (d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),2)*Wc - 2.0_rk*dTgc(:,2)*dot_product(dBi(:,2),Wc)                               &
+            - Tgc*dot_product(d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),2),Wc)) / dot_product(Bi,Wc)
+    end subroutine
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_d2Tgc_nurbs_2d_scalar(Xt, knot1, knot2, degree, nc, Wc, d2Tgc, dTgc, Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_2der, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_d2Tgc_bspline_2d_vector(Xt, knot1, knot2, degree, nc, ng, d2Tgc, dTgc, Tgc)
+        real(rk), intent(in), contiguous :: Xt(:,:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:)
+        integer, intent(in) :: degree(2)
+        integer, intent(in) :: nc(2)
+        integer, intent(in) :: ng(2)
+        real(rk), allocatable, intent(out) :: d2Tgc(:,:,:)
+        real(rk), allocatable, intent(out) :: dTgc(:,:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:,:)
+        real(rk) :: d2B1(nc(1)), d2B2(nc(2))
+        real(rk) :: dB1(nc(1)), dB2(nc(2))
+        real(rk) :: B1(nc(1)), B2(nc(2))
+        integer :: i
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:)
-    integer, intent(in) :: degree(2)
-    integer, intent(in) :: nc(2)
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable, intent(out) :: d2Tgc(:,:)
-    real(rk), allocatable, intent(out) :: dTgc(:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:)
-    real(rk), allocatable :: d2Bi(:,:), d2B1(:), d2B2(:)
-    real(rk), allocatable :: dBi(:,:), dB1(:), dB2(:)
-    real(rk), allocatable :: Bi(:), B1(:), B2(:)
+        allocate(d2Tgc(ng(1)*ng(2), 2*nc(1)*nc(2), 2))
+        allocate(dTgc(ng(1)*ng(2), nc(1)*nc(2), 2))
+        allocate(Tgc(ng(1)*ng(2), nc(1)*nc(2)))
+        do concurrent (i = 1: size(Xt, 1))
+            call basis_bspline_2der(Xt(i,1), knot1, nc(1), degree(1), d2B1, dB1, B1)
+            call basis_bspline_2der(Xt(i,2), knot2, nc(2), degree(2), d2B2, dB2, B2)
 
-    allocate(B1(nc(1)), B2(nc(2)))
-    allocate(dB1(nc(1)), dB2(nc(2)))
-    allocate(d2B1(nc(1)), d2B2(nc(2)))
-    allocate(Bi(nc(1)*nc(2)), dBi(nc(1)*nc(2), 2), d2Bi(2*nc(1)*nc(2), 2))
+            Tgc(i,:) = kron(B2, B1)
 
-    allocate(Tgc(nc(1)*nc(2)), dTgc(nc(1)*nc(2), 2), d2Tgc(2*nc(1)*nc(2), 2))
+            dTgc(i,:,1) = kron(B2, dB1)
+            dTgc(i,:,2) = kron(dB2, B1)
 
-    call basis_bspline_2der(Xt(1), knot1, nc(1), degree(1), d2B1, dB1, B1)
-    call basis_bspline_2der(Xt(2), knot2, nc(2), degree(2), d2B2, dB2, B2)
-
-    Bi = kron(B2, B1)
-
-    Tgc = Bi*(Wc/(dot_product(Bi,Wc)))
-
-    dBi(:,1) = kron(B2, dB1)
-    dBi(:,2) = kron(dB2, B1)
-
-    dTgc(:,1) = ( dBi(:,1)*Wc - Tgc*dot_product(dBi(:,1),Wc) ) / dot_product(Bi,Wc)
-    dTgc(:,2) = ( dBi(:,2)*Wc - Tgc*dot_product(dBi(:,2),Wc) ) / dot_product(Bi,Wc)
-
-    d2Bi(1:nc(1)*nc(2)              ,1) = kron(B2, d2B1)
-    d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),1) = kron(dB2, dB1)
-    d2Bi(1:nc(1)*nc(2)              ,2) = kron(dB2, dB1)
-    d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),2) = kron(d2B2, B1)
-
-    d2Tgc(1:nc(1)*nc(2)              ,1) = &
-        (d2Bi(1:nc(1)*nc(2)              ,1)*Wc - 2.0_rk*dTgc(:,1)*dot_product(dBi(:,1),Wc)                               &
-        - Tgc*dot_product(d2Bi(1:nc(1)*nc(2)              ,1),Wc)) / dot_product(Bi,Wc)
-    d2Tgc(nc(1)*nc(2)+1:2*nc(1)*nc(2),1) = &
-        (d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),1)*Wc - dTgc(:,1)*dot_product(dBi(:,2),Wc) - dTgc(:,2)*dot_product(dBi(:,1),Wc) &
-        - Tgc*dot_product(d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),1),Wc)) / dot_product(Bi,Wc)
-    d2Tgc(1:nc(1)*nc(2)              ,2) = &
-        (d2Bi(1:nc(1)*nc(2)              ,2)*Wc - dTgc(:,1)*dot_product(dBi(:,2),Wc) - dTgc(:,2)*dot_product(dBi(:,1),Wc) &
-        - Tgc*dot_product(d2Bi(1:nc(1)*nc(2)              ,2),Wc)) / dot_product(Bi,Wc)
-    d2Tgc(nc(1)*nc(2)+1:2*nc(1)*nc(2),2) = &
-        (d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),2)*Wc - 2.0_rk*dTgc(:,2)*dot_product(dBi(:,2),Wc)                               &
-        - Tgc*dot_product(d2Bi(nc(1)*nc(2)+1:2*nc(1)*nc(2),2),Wc)) / dot_product(Bi,Wc)
-end subroutine
-!===============================================================================
+            d2Tgc(i,1:nc(1)*nc(2)              ,1) = kron(B2, d2B1)
+            d2Tgc(i,nc(1)*nc(2)+1:2*nc(1)*nc(2),1) = kron(dB2, dB1)
+            d2Tgc(i,1:nc(1)*nc(2)              ,2) = kron(dB2, dB1)
+            d2Tgc(i,nc(1)*nc(2)+1:2*nc(1)*nc(2),2) = kron(d2B2, B1)
+        end do
+    end subroutine
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_d2Tgc_bspline_2d_vector(Xt, knot1, knot2, degree, nc, ng, d2Tgc, dTgc, Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_2der, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_d2Tgc_bspline_2d_scalar(Xt, knot1, knot2, degree, nc, d2Tgc, dTgc, Tgc)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:)
+        integer, intent(in) :: degree(2)
+        integer, intent(in) :: nc(2)
+        real(rk), allocatable, intent(out) :: d2Tgc(:,:)
+        real(rk), allocatable, intent(out) :: dTgc(:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:)
+        real(rk) :: d2B1(nc(1)), d2B2(nc(2))
+        real(rk) :: dB1(nc(1)), dB2(nc(2))
+        real(rk) :: B1(nc(1)), B2(nc(2))
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:,:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:)
-    integer, intent(in) :: degree(2)
-    integer, intent(in) :: nc(2)
-    integer, intent(in) :: ng(2)
-    real(rk), allocatable, intent(out) :: d2Tgc(:,:,:)
-    real(rk), allocatable, intent(out) :: dTgc(:,:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:,:)
-    real(rk), allocatable :: d2B1(:), d2B2(:)
-    real(rk), allocatable :: dB1(:), dB2(:)
-    real(rk), allocatable :: B1(:), B2(:)
-    integer :: i
+        allocate(d2Tgc(2*nc(1)*nc(2), 2))
+        allocate(dTgc(nc(1)*nc(2), 2))
+        allocate(Tgc(nc(1)*nc(2)))
+        call basis_bspline_2der(Xt(1), knot1, nc(1), degree(1), d2B1, dB1, B1)
+        call basis_bspline_2der(Xt(2), knot2, nc(2), degree(2), d2B2, dB2, B2)
+        Tgc = kron(B2, B1)
 
-    allocate(d2Tgc(ng(1)*ng(2), 2*nc(1)*nc(2), 2))
-    allocate(dTgc(ng(1)*ng(2), nc(1)*nc(2), 2))
-    allocate(Tgc(ng(1)*ng(2), nc(1)*nc(2)))
-    do i = 1, size(Xt, 1)
-        call basis_bspline_2der(Xt(i,1), knot1, nc(1), degree(1), d2B1, dB1, B1)
-        call basis_bspline_2der(Xt(i,2), knot2, nc(2), degree(2), d2B2, dB2, B2)
+        dTgc(:,1) = kron(B2, dB1)
+        dTgc(:,2) = kron(dB2, B1)
 
-        Tgc(i,:) = kron(B2, B1)
-
-        dTgc(i,:,1) = kron(B2, dB1)
-        dTgc(i,:,2) = kron(dB2, B1)
-
-        d2Tgc(i,1:nc(1)*nc(2)              ,1) = kron(B2, d2B1)
-        d2Tgc(i,nc(1)*nc(2)+1:2*nc(1)*nc(2),1) = kron(dB2, dB1)
-        d2Tgc(i,1:nc(1)*nc(2)              ,2) = kron(dB2, dB1)
-        d2Tgc(i,nc(1)*nc(2)+1:2*nc(1)*nc(2),2) = kron(d2B2, B1)
-    end do
-end subroutine
-!===============================================================================
+        d2Tgc(1:nc(1)*nc(2)              ,1) = kron(B2, d2B1)
+        d2Tgc(nc(1)*nc(2)+1:2*nc(1)*nc(2),1) = kron(dB2, dB1)
+        d2Tgc(1:nc(1)*nc(2)              ,2) = kron(dB2, dB1)
+        d2Tgc(nc(1)*nc(2)+1:2*nc(1)*nc(2),2) = kron(d2B2, B1)
+    end subroutine
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_d2Tgc_bspline_2d_scalar(Xt, knot1, knot2, degree, nc, d2Tgc, dTgc, Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_2der, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Tgc_nurbs_2d_vector(Xt, knot1, knot2, degree, nc, ng, Wc) result(Tgc)
+        real(rk), intent(in), contiguous :: Xt(:,:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:)
+        integer, intent(in) :: degree(2)
+        integer, intent(in) :: nc(2)
+        integer, intent(in) :: ng(2)
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable :: Tgc(:,:)
+        real(rk), allocatable :: Tgci(:)
+        integer :: i
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:)
-    integer, intent(in) :: degree(2)
-    integer, intent(in) :: nc(2)
-    real(rk), allocatable, intent(out) :: d2Tgc(:,:)
-    real(rk), allocatable, intent(out) :: dTgc(:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:)
-    real(rk), allocatable :: d2B1(:), d2B2(:)
-    real(rk), allocatable :: dB1(:), dB2(:)
-    real(rk), allocatable :: B1(:), B2(:)
-
-    allocate(d2Tgc(2*nc(1)*nc(2), 2))
-    allocate(dTgc(nc(1)*nc(2), 2))
-    allocate(Tgc(nc(1)*nc(2)))
-    call basis_bspline_2der(Xt(1), knot1, nc(1), degree(1), d2B1, dB1, B1)
-    call basis_bspline_2der(Xt(2), knot2, nc(2), degree(2), d2B2, dB2, B2)
-    Tgc = kron(B2, B1)
-
-    dTgc(:,1) = kron(B2, dB1)
-    dTgc(:,2) = kron(dB2, B1)
-
-    d2Tgc(1:nc(1)*nc(2)              ,1) = kron(B2, d2B1)
-    d2Tgc(nc(1)*nc(2)+1:2*nc(1)*nc(2),1) = kron(dB2, dB1)
-    d2Tgc(1:nc(1)*nc(2)              ,2) = kron(dB2, dB1)
-    d2Tgc(nc(1)*nc(2)+1:2*nc(1)*nc(2),2) = kron(d2B2, B1)
-end subroutine
-!===============================================================================
+        allocate(Tgc(ng(1)*ng(2), nc(1)*nc(2)))
+        allocate(Tgci(nc(1)*nc(2)))
+        do concurrent (i = 1: size(Xt, 1))
+            Tgci = kron(&
+                basis_bspline(Xt(i,2), knot2, nc(2), degree(2)),&
+                basis_bspline(Xt(i,1), knot1, nc(1), degree(1)))
+            Tgc(i,:) = Tgci*(Wc/(dot_product(Tgci,Wc)))
+        end do
+    end function
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Tgc_nurbs_2d_vector(Xt, knot1, knot2, degree, nc, ng, Wc) result(Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Tgc_nurbs_2d_scalar(Xt, knot1, knot2, degree, nc, Wc) result(Tgc)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:)
+        integer, intent(in) :: degree(2)
+        integer, intent(in) :: nc(2)
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable :: Tgc(:)
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:,:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:)
-    integer, intent(in) :: degree(2)
-    integer, intent(in) :: nc(2)
-    integer, intent(in) :: ng(2)
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable :: Tgc(:,:)
-    real(rk), allocatable :: Tgci(:)
-    integer :: i
-
-    allocate(Tgc(ng(1)*ng(2), nc(1)*nc(2)))
-    allocate(Tgci(nc(1)*nc(2)))
-    !$omp parallel do private(Tgci)
-    do i = 1, size(Xt, 1)
-        Tgci = kron(&
-            basis_bspline(Xt(i,2), knot2, nc(2), degree(2)),&
-            basis_bspline(Xt(i,1), knot1, nc(1), degree(1)))
-        Tgc(i,:) = Tgci*(Wc/(dot_product(Tgci,Wc)))
-    end do
-    !$omp end parallel do
-end function
-!===============================================================================
+        allocate(Tgc(nc(1)*nc(2)))
+        Tgc = kron(&
+            basis_bspline(Xt(2), knot2, nc(2), degree(2)),&
+            basis_bspline(Xt(1), knot1, nc(1), degree(1)))
+        Tgc = Tgc*(Wc/(dot_product(Tgc,Wc)))
+    end function
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Tgc_nurbs_2d_scalar(Xt, knot1, knot2, degree, nc, Wc) result(Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Tgc_bspline_2d_vector(Xt, knot1, knot2, degree, nc, ng) result(Tgc)
+        real(rk), intent(in), contiguous :: Xt(:,:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:)
+        integer, intent(in) :: degree(2)
+        integer, intent(in) :: nc(2)
+        integer, intent(in) :: ng(2)
+        real(rk), allocatable :: Tgc(:,:)
+        integer :: i
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:)
-    integer, intent(in) :: degree(2)
-    integer, intent(in) :: nc(2)
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable :: Tgc(:)
-
-    allocate(Tgc(nc(1)*nc(2)))
-    Tgc = kron(&
-        basis_bspline(Xt(2), knot2, nc(2), degree(2)),&
-        basis_bspline(Xt(1), knot1, nc(1), degree(1)))
-    Tgc = Tgc*(Wc/(dot_product(Tgc,Wc)))
-end function
-!===============================================================================
+        allocate(Tgc(ng(1)*ng(2), nc(1)*nc(2)))
+        do concurrent (i = 1: size(Xt, 1))
+            Tgc(i,:) = kron(&
+                basis_bspline(Xt(i,2), knot2, nc(2), degree(2)),&
+                basis_bspline(Xt(i,1), knot1, nc(1), degree(1)))
+        end do
+    end function
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Tgc_bspline_2d_vector(Xt, knot1, knot2, degree, nc, ng) result(Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Tgc_bspline_2d_scalar(Xt, knot1, knot2, degree, nc) result(Tgc)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:)
+        integer, intent(in) :: degree(2)
+        integer, intent(in) :: nc(2)
+        real(rk), allocatable :: Tgc(:)
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:,:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:)
-    integer, intent(in) :: degree(2)
-    integer, intent(in) :: nc(2)
-    integer, intent(in) :: ng(2)
-    real(rk), allocatable :: Tgc(:,:)
-    integer :: i
-
-    allocate(Tgc(ng(1)*ng(2), nc(1)*nc(2)))
-    !$omp parallel do
-    do i = 1, size(Xt, 1)
-        Tgc(i,:) = kron(&
-            basis_bspline(Xt(i,2), knot2, nc(2), degree(2)),&
-            basis_bspline(Xt(i,1), knot1, nc(1), degree(1)))
-    end do
-    !$omp end parallel do
-end function
-!===============================================================================
+        allocate(Tgc(nc(1)*nc(2)))
+        Tgc = kron(&
+            basis_bspline(Xt(2), knot2, nc(2), degree(2)),&
+            basis_bspline(Xt(1), knot1, nc(1), degree(1)))
+    end function
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Tgc_bspline_2d_scalar(Xt, knot1, knot2, degree, nc) result(Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function nearest_point_help_2d(ng, Xg, point_Xg) result(distances)
+        integer, intent(in) :: ng(2)
+        real(rk), intent(in), contiguous :: Xg(:,:)
+        real(rk), intent(in), contiguous :: point_Xg(:)
+        real(rk), allocatable :: distances(:)
+        integer :: i
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:)
-    integer, intent(in) :: degree(2)
-    integer, intent(in) :: nc(2)
-    real(rk), allocatable :: Tgc(:)
+        allocate(distances(ng(1)*ng(2)))
+        do concurrent (i = 1: ng(1)*ng(2))
+            distances(i) = norm2(Xg(i,:) - point_Xg)
+        end do
+    end function
+    !===============================================================================
 
-    allocate(Tgc(nc(1)*nc(2)))
-    Tgc = kron(&
-        basis_bspline(Xt(2), knot2, nc(2), degree(2)),&
-        basis_bspline(Xt(1), knot1, nc(1), degree(1)))
-end function
-!===============================================================================
-
-
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-pure function nearest_point_help_2d(ng, Xg, point_Xg) result(distances)
-    use forcad_kinds, only: rk
-
-    implicit none
-    integer, intent(in) :: ng(2)
-    real(rk), intent(in), contiguous :: Xg(:,:)
-    real(rk), intent(in), contiguous :: point_Xg(:)
-    real(rk), allocatable :: distances(:)
-    integer :: i
-
-    allocate(distances(ng(1)*ng(2)))
-    do concurrent (i = 1:ng(1)*ng(2))
-        distances(i) = norm2(Xg(i,:) - point_Xg)
-    end do
-end function
-!===============================================================================
+end module forcad_nurbs_surface

--- a/src/forcad_nurbs_volume.f90
+++ b/src/forcad_nurbs_volume.f90
@@ -1597,7 +1597,7 @@ contains
         integer, intent(in) :: dir
         real(rk), intent(in), contiguous :: Xth(:)
         integer, intent(in), contiguous :: r(:)
-        integer :: k, i, s, dim, j, n_new
+        integer :: k, i, s, d, j, n_new
         real(rk), allocatable :: Xc(:,:), Xcw(:,:), Xcw_new(:,:), Xc_new(:,:), Wc_new(:), knot_new(:)
         real(rk), allocatable :: Xc4(:,:,:,:)
 
@@ -1614,14 +1614,14 @@ contains
                         s = 0
                     end if
 
-                    dim = size(this%Xc,2)
-                    allocate(Xcw(size(this%Xc,1),dim+1))
+                    d = size(this%Xc,2)
+                    allocate(Xcw(size(this%Xc,1),d+1))
                     do j = 1, size(this%Xc,1)
-                        Xcw(j,1:dim) = this%Xc(j,1:dim)*this%Wc(j)
+                        Xcw(j,1:d) = this%Xc(j,1:d)*this%Wc(j)
                     end do
-                    Xcw(:,dim+1) = this%Wc(:)
+                    Xcw(:,d+1) = this%Wc(:)
 
-                    Xcw = reshape(Xcw,[this%nc(1),this%nc(2)*this%nc(3)*(dim+1)])
+                    Xcw = reshape(Xcw,[this%nc(1),this%nc(2)*this%nc(3)*(d+1)])
 
                     call insert_knot_A_5_1(&
                         this%degree(1),&
@@ -1635,14 +1635,14 @@ contains
                         knot_new,&
                         Xcw_new)
 
-                    Xcw_new = reshape(Xcw_new,[(n_new+1)*this%nc(2)*this%nc(3),dim+1])
+                    Xcw_new = reshape(Xcw_new,[(n_new+1)*this%nc(2)*this%nc(3),d+1])
 
-                    allocate(Xc_new(1:(n_new+1)*this%nc(2)*this%nc(3),1:dim))
+                    allocate(Xc_new(1:(n_new+1)*this%nc(2)*this%nc(3),1:d))
                     allocate(Wc_new(1:(n_new+1)*this%nc(2)*this%nc(3)))
                     do j = 1, (n_new+1)*this%nc(2)*this%nc(3)
-                        Xc_new(j,1:dim) = Xcw_new(j,1:dim)/Xcw_new(j,dim+1)
+                        Xc_new(j,1:d) = Xcw_new(j,1:d)/Xcw_new(j,d+1)
                     end do
-                    Wc_new(:) = Xcw_new(:,dim+1)
+                    Wc_new(:) = Xcw_new(:,d+1)
 
                     call this%set(knot1=knot_new, knot2=this%get_knot(2), knot3=this%get_knot(3), Xc=Xc_new, Wc=Wc_new)
                     deallocate(Xcw, Xcw_new, Xc_new, Wc_new)
@@ -1659,9 +1659,9 @@ contains
                         s = 0
                     end if
 
-                    dim = size(this%Xc,2)
+                    d = size(this%Xc,2)
 
-                    Xc = reshape(this%Xc,[this%nc(1),this%nc(2)*this%nc(3)*dim])
+                    Xc = reshape(this%Xc,[this%nc(1),this%nc(2)*this%nc(3)*d])
 
                     call insert_knot_A_5_1(&
                         this%degree(1),&
@@ -1675,7 +1675,7 @@ contains
                         knot_new,&
                         Xc_new)
 
-                    Xc_new = reshape(Xc_new,[(n_new+1)*this%nc(2)*this%nc(3),dim])
+                    Xc_new = reshape(Xc_new,[(n_new+1)*this%nc(2)*this%nc(3),d])
 
                     call this%set(knot1=knot_new, knot2=this%get_knot(2), knot3=this%get_knot(3), Xc=Xc_new)
                 end do
@@ -1694,16 +1694,16 @@ contains
                         s = 0
                     end if
 
-                    dim = size(this%Xc,2)
-                    allocate(Xcw(size(this%Xc,1),dim+1))
+                    d = size(this%Xc,2)
+                    allocate(Xcw(size(this%Xc,1),d+1))
                     do j = 1, size(this%Xc,1)
-                        Xcw(j,1:dim) = this%Xc(j,1:dim)*this%Wc(j)
+                        Xcw(j,1:d) = this%Xc(j,1:d)*this%Wc(j)
                     end do
-                    Xcw(:,dim+1) = this%Wc(:)
+                    Xcw(:,d+1) = this%Wc(:)
 
-                    Xc4 = reshape(Xcw, [this%nc(1),this%nc(2),this%nc(3),dim+1])
-                    Xc4 = reshape(Xc4, [this%nc(2),this%nc(1),this%nc(3),dim+1], order=[2,1,3,4])
-                    Xcw = reshape(Xc4,[this%nc(2),this%nc(1)*this%nc(3)*(dim+1)])
+                    Xc4 = reshape(Xcw, [this%nc(1),this%nc(2),this%nc(3),d+1])
+                    Xc4 = reshape(Xc4, [this%nc(2),this%nc(1),this%nc(3),d+1], order=[2,1,3,4])
+                    Xcw = reshape(Xc4,[this%nc(2),this%nc(1)*this%nc(3)*(d+1)])
 
                     call insert_knot_A_5_1(&
                         this%degree(2),&
@@ -1717,16 +1717,16 @@ contains
                         knot_new,&
                         Xcw_new)
 
-                    Xc4 = reshape(Xcw_new, [n_new+1,this%nc(1),this%nc(3),dim+1])
-                    Xc4 = reshape(Xc4, [this%nc(1),n_new+1,this%nc(3),dim+1], order=[2,1,3,4])
-                    Xcw_new = reshape(Xc4,[this%nc(1)*(n_new+1)*this%nc(3),dim+1])
+                    Xc4 = reshape(Xcw_new, [n_new+1,this%nc(1),this%nc(3),d+1])
+                    Xc4 = reshape(Xc4, [this%nc(1),n_new+1,this%nc(3),d+1], order=[2,1,3,4])
+                    Xcw_new = reshape(Xc4,[this%nc(1)*(n_new+1)*this%nc(3),d+1])
 
-                    allocate(Xc_new(1:this%nc(1)*(n_new+1)*this%nc(3),1:dim))
+                    allocate(Xc_new(1:this%nc(1)*(n_new+1)*this%nc(3),1:d))
                     allocate(Wc_new(1:this%nc(1)*(n_new+1)*this%nc(3)))
                     do j = 1, this%nc(1)*(n_new+1)*this%nc(3)
-                        Xc_new(j,1:dim) = Xcw_new(j,1:dim)/Xcw_new(j,dim+1)
+                        Xc_new(j,1:d) = Xcw_new(j,1:d)/Xcw_new(j,d+1)
                     end do
-                    Wc_new(:) = Xcw_new(:,dim+1)
+                    Wc_new(:) = Xcw_new(:,d+1)
 
                     call this%set(knot1=this%get_knot(1), knot2=knot_new, knot3=this%get_knot(3), Xc=Xc_new, Wc=Wc_new)
                     deallocate(Xcw, Xcw_new, Xc_new, Wc_new)
@@ -1742,11 +1742,11 @@ contains
                         s = 0
                     end if
 
-                    dim = size(this%Xc,2)
+                    d = size(this%Xc,2)
 
-                    Xc4 = reshape(this%Xc, [this%nc(1),this%nc(2),this%nc(3),dim])
-                    Xc4 = reshape(Xc4, [this%nc(2),this%nc(1),this%nc(3),dim], order=[2,1,3,4])
-                    Xc = reshape(Xc4,[this%nc(2),this%nc(1)*this%nc(3)*dim])
+                    Xc4 = reshape(this%Xc, [this%nc(1),this%nc(2),this%nc(3),d])
+                    Xc4 = reshape(Xc4, [this%nc(2),this%nc(1),this%nc(3),d], order=[2,1,3,4])
+                    Xc = reshape(Xc4,[this%nc(2),this%nc(1)*this%nc(3)*d])
 
                     call insert_knot_A_5_1(&
                         this%degree(2),&
@@ -1760,9 +1760,9 @@ contains
                         knot_new,&
                         Xc_new)
 
-                    Xc4 = reshape(Xc_new, [n_new+1,this%nc(1),this%nc(3),dim])
-                    Xc4 = reshape(Xc4, [this%nc(1),n_new+1,this%nc(3),dim], order=[2,1,3,4])
-                    Xc_new = reshape(Xc4,[this%nc(1)*(n_new+1)*this%nc(3),dim])
+                    Xc4 = reshape(Xc_new, [n_new+1,this%nc(1),this%nc(3),d])
+                    Xc4 = reshape(Xc4, [this%nc(1),n_new+1,this%nc(3),d], order=[2,1,3,4])
+                    Xc_new = reshape(Xc4,[this%nc(1)*(n_new+1)*this%nc(3),d])
 
                     call this%set(knot1=this%get_knot(1), knot2=knot_new, knot3=this%get_knot(3), Xc=Xc_new)
                 end do
@@ -1782,16 +1782,16 @@ contains
                         s = 0
                     end if
 
-                    dim = size(this%Xc,2)
-                    allocate(Xcw(size(this%Xc,1),dim+1))
+                    d = size(this%Xc,2)
+                    allocate(Xcw(size(this%Xc,1),d+1))
                     do j = 1, size(this%Xc,1)
-                        Xcw(j,1:dim) = this%Xc(j,1:dim)*this%Wc(j)
+                        Xcw(j,1:d) = this%Xc(j,1:d)*this%Wc(j)
                     end do
-                    Xcw(:,dim+1) = this%Wc(:)
+                    Xcw(:,d+1) = this%Wc(:)
 
-                    Xc4 = reshape(Xcw, [this%nc(1),this%nc(2),this%nc(3),dim+1])
-                    Xc4 = reshape(Xc4, [this%nc(3),this%nc(2),this%nc(1),dim+1], order=[3,2,1,4])
-                    Xcw = reshape(Xc4,[this%nc(3),this%nc(2)*this%nc(1)*(dim+1)])
+                    Xc4 = reshape(Xcw, [this%nc(1),this%nc(2),this%nc(3),d+1])
+                    Xc4 = reshape(Xc4, [this%nc(3),this%nc(2),this%nc(1),d+1], order=[3,2,1,4])
+                    Xcw = reshape(Xc4,[this%nc(3),this%nc(2)*this%nc(1)*(d+1)])
 
                     call insert_knot_A_5_1(&
                         this%degree(3),&
@@ -1805,16 +1805,16 @@ contains
                         knot_new,&
                         Xcw_new)
 
-                    Xc4 = reshape(Xcw_new, [n_new+1,this%nc(2),this%nc(1),dim+1])
-                    Xc4 = reshape(Xc4, [this%nc(1),this%nc(2),n_new+1,dim+1], order=[3,2,1,4])
-                    Xcw_new = reshape(Xc4,[this%nc(1)*this%nc(2)*(n_new+1),dim+1])
+                    Xc4 = reshape(Xcw_new, [n_new+1,this%nc(2),this%nc(1),d+1])
+                    Xc4 = reshape(Xc4, [this%nc(1),this%nc(2),n_new+1,d+1], order=[3,2,1,4])
+                    Xcw_new = reshape(Xc4,[this%nc(1)*this%nc(2)*(n_new+1),d+1])
 
-                    allocate(Xc_new(1:this%nc(1)*this%nc(2)*(n_new+1),1:dim))
+                    allocate(Xc_new(1:this%nc(1)*this%nc(2)*(n_new+1),1:d))
                     allocate(Wc_new(1:this%nc(1)*this%nc(2)*(n_new+1)))
                     do j = 1, this%nc(1)*this%nc(2)*(n_new+1)
-                        Xc_new(j,1:dim) = Xcw_new(j,1:dim)/Xcw_new(j,dim+1)
+                        Xc_new(j,1:d) = Xcw_new(j,1:d)/Xcw_new(j,d+1)
                     end do
-                    Wc_new(:) = Xcw_new(:,dim+1)
+                    Wc_new(:) = Xcw_new(:,d+1)
 
                     call this%set(knot1=this%get_knot(1), knot2=this%get_knot(2), knot3=knot_new, Xc=Xc_new, Wc=Wc_new)
                     deallocate(Xcw, Xcw_new, Xc_new, Wc_new)
@@ -1830,11 +1830,11 @@ contains
                         s = 0
                     end if
 
-                    dim = size(this%Xc,2)
+                    d = size(this%Xc,2)
 
-                    Xc4 = reshape(this%Xc, [this%nc(1),this%nc(2),this%nc(3),dim])
-                    Xc4 = reshape(Xc4, [this%nc(3),this%nc(2),this%nc(1),dim], order=[3,2,1,4])
-                    Xc = reshape(Xc4,[this%nc(3),this%nc(2)*this%nc(1)*dim])
+                    Xc4 = reshape(this%Xc, [this%nc(1),this%nc(2),this%nc(3),d])
+                    Xc4 = reshape(Xc4, [this%nc(3),this%nc(2),this%nc(1),d], order=[3,2,1,4])
+                    Xc = reshape(Xc4,[this%nc(3),this%nc(2)*this%nc(1)*d])
 
                     call insert_knot_A_5_1(&
                         this%degree(3),&
@@ -1848,9 +1848,9 @@ contains
                         knot_new,&
                         Xc_new)
 
-                    Xc4 = reshape(Xc_new, [n_new+1,this%nc(2),this%nc(1),dim])
-                    Xc4 = reshape(Xc4, [this%nc(1),this%nc(2),n_new+1,dim], order=[3,2,1,4])
-                    Xc_new = reshape(Xc4, [this%nc(1)*this%nc(2)*(n_new+1),dim])
+                    Xc4 = reshape(Xc_new, [n_new+1,this%nc(2),this%nc(1),d])
+                    Xc4 = reshape(Xc4, [this%nc(1),this%nc(2),n_new+1,d], order=[3,2,1,4])
+                    Xc_new = reshape(Xc4, [this%nc(1)*this%nc(2)*(n_new+1),d])
 
                     call this%set(knot1=this%get_knot(1), knot2=this%get_knot(2), knot3=knot_new, Xc=Xc_new)
                 end do
@@ -1873,7 +1873,7 @@ contains
         integer, intent(in) :: dir
         integer, intent(in) :: t
         real(rk), allocatable :: Xc(:,:), Xcw(:,:), Xcw_new(:,:), Xc_new(:,:), Wc_new(:), knot_new(:)
-        integer :: nc_new, dim, j
+        integer :: nc_new, d, j
         real(rk), allocatable:: Xc4(:,:,:,:)
 
 
@@ -1881,38 +1881,38 @@ contains
 
             if (allocated(this%Wc)) then ! NURBS
 
-                dim = size(this%Xc,2)
-                allocate(Xcw(size(this%Xc,1),dim+1))
+                d = size(this%Xc,2)
+                allocate(Xcw(size(this%Xc,1),d+1))
                 do j = 1, size(this%Xc,1)
-                    Xcw(j,1:dim) = this%Xc(j,1:dim)*this%Wc(j)
+                    Xcw(j,1:d) = this%Xc(j,1:d)*this%Wc(j)
                 end do
-                Xcw(:,dim+1) = this%Wc(:)
+                Xcw(:,d+1) = this%Wc(:)
 
-                Xcw = reshape(Xcw,[this%nc(1),this%nc(2)*this%nc(3)*(dim+1)],order=[1,2])
+                Xcw = reshape(Xcw,[this%nc(1),this%nc(2)*this%nc(3)*(d+1)],order=[1,2])
 
                 call elevate_degree_A_5_9(t, this%knot1, this%degree(1), Xcw, nc_new, knot_new, Xcw_new)
 
-                Xcw_new = reshape(Xcw_new,[nc_new*this%nc(2)*this%nc(3),dim+1],order=[1,2])
+                Xcw_new = reshape(Xcw_new,[nc_new*this%nc(2)*this%nc(3),d+1],order=[1,2])
 
-                allocate(Xc_new(1:nc_new*this%nc(2)*this%nc(3),1:dim))
+                allocate(Xc_new(1:nc_new*this%nc(2)*this%nc(3),1:d))
                 allocate(Wc_new(1:nc_new*this%nc(2)*this%nc(3)))
                 do j = 1, nc_new*this%nc(2)*this%nc(3)
-                    Xc_new(j,1:dim) = Xcw_new(j,1:dim)/Xcw_new(j,dim+1)
+                    Xc_new(j,1:d) = Xcw_new(j,1:d)/Xcw_new(j,d+1)
                 end do
-                Wc_new(:) = Xcw_new(:,dim+1)
+                Wc_new(:) = Xcw_new(:,d+1)
 
                 call this%set(knot1=knot_new, knot2=this%get_knot(2), knot3=this%get_knot(3), Xc=Xc_new, Wc=Wc_new)
                 deallocate(Xcw, Xcw_new, Xc_new, Wc_new)
 
             else ! B-Spline
 
-                dim = size(this%Xc,2)
+                d = size(this%Xc,2)
 
-                Xc = reshape(this%Xc,[this%nc(1),this%nc(2)*this%nc(3)*dim],order=[1,2])
+                Xc = reshape(this%Xc,[this%nc(1),this%nc(2)*this%nc(3)*d],order=[1,2])
 
                 call elevate_degree_A_5_9(t, this%knot1, this%degree(1), Xc, nc_new, knot_new, Xc_new)
 
-                Xc_new = reshape(Xc_new,[nc_new*this%nc(2)*this%nc(3),dim],order=[1,2])
+                Xc_new = reshape(Xc_new,[nc_new*this%nc(2)*this%nc(3),d],order=[1,2])
 
                 call this%set(knot1=knot_new, knot2=this%get_knot(2), knot3=this%get_knot(3), Xc=Xc_new)
 
@@ -1923,49 +1923,49 @@ contains
             if (allocated(this%Wc)) then ! NURBS
 
 
-                dim = size(this%Xc,2)
-                allocate(Xcw(size(this%Xc,1),dim+1))
+                d = size(this%Xc,2)
+                allocate(Xcw(size(this%Xc,1),d+1))
                 do j = 1, size(this%Xc,1)
-                    Xcw(j,1:dim) = this%Xc(j,1:dim)*this%Wc(j)
+                    Xcw(j,1:d) = this%Xc(j,1:d)*this%Wc(j)
                 end do
 
-                Xcw(:,dim+1) = this%Wc(:)
+                Xcw(:,d+1) = this%Wc(:)
 
-                Xc4 = reshape(Xcw, [this%nc(1),this%nc(2),this%nc(3),dim+1])
-                Xc4 = reshape(Xc4, [this%nc(2),this%nc(1),this%nc(3),dim+1], order=[2,1,3,4])
-                Xcw = reshape(Xc4,[this%nc(2),this%nc(1)*this%nc(3)*(dim+1)])
+                Xc4 = reshape(Xcw, [this%nc(1),this%nc(2),this%nc(3),d+1])
+                Xc4 = reshape(Xc4, [this%nc(2),this%nc(1),this%nc(3),d+1], order=[2,1,3,4])
+                Xcw = reshape(Xc4,[this%nc(2),this%nc(1)*this%nc(3)*(d+1)])
 
 
                 call elevate_degree_A_5_9(t, this%knot2, this%degree(2), Xcw, nc_new, knot_new, Xcw_new)
 
-                Xc4 = reshape(Xcw_new, [nc_new,this%nc(1),this%nc(3),dim+1])
-                Xc4 = reshape(Xc4, [this%nc(1),nc_new,this%nc(3),dim+1], order=[2,1,3,4])
-                Xcw_new = reshape(Xc4,[this%nc(1)*nc_new*this%nc(3),dim+1])
+                Xc4 = reshape(Xcw_new, [nc_new,this%nc(1),this%nc(3),d+1])
+                Xc4 = reshape(Xc4, [this%nc(1),nc_new,this%nc(3),d+1], order=[2,1,3,4])
+                Xcw_new = reshape(Xc4,[this%nc(1)*nc_new*this%nc(3),d+1])
 
-                allocate(Xc_new(1:this%nc(1)*nc_new*this%nc(3),1:dim))
+                allocate(Xc_new(1:this%nc(1)*nc_new*this%nc(3),1:d))
                 allocate(Wc_new(1:this%nc(1)*nc_new*this%nc(3)))
                 do j = 1, this%nc(1)*nc_new*this%nc(3)
-                    Xc_new(j,1:dim) = Xcw_new(j,1:dim)/Xcw_new(j,dim+1)
+                    Xc_new(j,1:d) = Xcw_new(j,1:d)/Xcw_new(j,d+1)
                 end do
 
-                Wc_new(:) = Xcw_new(:,dim+1)
+                Wc_new(:) = Xcw_new(:,d+1)
 
                 call this%set(knot1=this%get_knot(1), knot2=knot_new, knot3=this%get_knot(3), Xc=Xc_new, Wc=Wc_new)
                 deallocate(Xcw, Xcw_new, Xc_new, Wc_new)
 
             else ! B-Spline
 
-                dim = size(this%Xc,2)
+                d = size(this%Xc,2)
 
-                Xc4 = reshape(this%Xc, [this%nc(1),this%nc(2),this%nc(3),dim])
-                Xc4 = reshape(Xc4, [this%nc(2),this%nc(1),this%nc(3),dim], order=[2,1,3,4])
-                Xc = reshape(Xc4,[this%nc(2),this%nc(1)*this%nc(3)*dim])
+                Xc4 = reshape(this%Xc, [this%nc(1),this%nc(2),this%nc(3),d])
+                Xc4 = reshape(Xc4, [this%nc(2),this%nc(1),this%nc(3),d], order=[2,1,3,4])
+                Xc = reshape(Xc4,[this%nc(2),this%nc(1)*this%nc(3)*d])
 
                 call elevate_degree_A_5_9(t, this%knot2, this%degree(2), Xc, nc_new, knot_new, Xc_new)
 
-                Xc4 = reshape(Xc_new, [nc_new,this%nc(1),this%nc(3),dim])
-                Xc4 = reshape(Xc4, [this%nc(1),nc_new,this%nc(3),dim], order=[2,1,3,4])
-                Xc_new = reshape(Xc4,[this%nc(1)*nc_new*this%nc(3),dim])
+                Xc4 = reshape(Xc_new, [nc_new,this%nc(1),this%nc(3),d])
+                Xc4 = reshape(Xc4, [this%nc(1),nc_new,this%nc(3),d], order=[2,1,3,4])
+                Xc_new = reshape(Xc4,[this%nc(1)*nc_new*this%nc(3),d])
 
                 call this%set(knot1=this%get_knot(1), knot2=knot_new, knot3=this%get_knot(3), Xc=Xc_new)
 
@@ -1975,48 +1975,48 @@ contains
 
             if (allocated(this%Wc)) then ! NURBS
 
-                dim = size(this%Xc,2)
-                allocate(Xcw(size(this%Xc,1),dim+1))
+                d = size(this%Xc,2)
+                allocate(Xcw(size(this%Xc,1),d+1))
                 do j = 1, size(this%Xc,1)
-                    Xcw(j,1:dim) = this%Xc(j,1:dim)*this%Wc(j)
+                    Xcw(j,1:d) = this%Xc(j,1:d)*this%Wc(j)
                 end do
 
-                Xcw(:,dim+1) = this%Wc(:)
+                Xcw(:,d+1) = this%Wc(:)
 
-                Xc4 = reshape(Xcw, [this%nc(1),this%nc(2),this%nc(3),dim+1])
-                Xc4 = reshape(Xc4, [this%nc(3),this%nc(2),this%nc(1),dim+1], order=[3,2,1,4])
-                Xcw = reshape(Xc4,[this%nc(3),this%nc(2)*this%nc(1)*(dim+1)])
+                Xc4 = reshape(Xcw, [this%nc(1),this%nc(2),this%nc(3),d+1])
+                Xc4 = reshape(Xc4, [this%nc(3),this%nc(2),this%nc(1),d+1], order=[3,2,1,4])
+                Xcw = reshape(Xc4,[this%nc(3),this%nc(2)*this%nc(1)*(d+1)])
 
                 call elevate_degree_A_5_9(t, this%knot3, this%degree(3), Xcw, nc_new, knot_new, Xcw_new)
 
-                Xc4 = reshape(Xcw_new, [nc_new,this%nc(2),this%nc(1),dim+1])
-                Xc4 = reshape(Xc4, [this%nc(1),this%nc(2),nc_new,dim+1], order=[3,2,1,4])
-                Xcw_new = reshape(Xc4,[this%nc(1)*this%nc(2)*nc_new,dim+1])
+                Xc4 = reshape(Xcw_new, [nc_new,this%nc(2),this%nc(1),d+1])
+                Xc4 = reshape(Xc4, [this%nc(1),this%nc(2),nc_new,d+1], order=[3,2,1,4])
+                Xcw_new = reshape(Xc4,[this%nc(1)*this%nc(2)*nc_new,d+1])
 
-                allocate(Xc_new(1:this%nc(1)*this%nc(2)*nc_new,1:dim))
+                allocate(Xc_new(1:this%nc(1)*this%nc(2)*nc_new,1:d))
                 allocate(Wc_new(1:this%nc(1)*this%nc(2)*nc_new))
                 do j = 1, this%nc(1)*this%nc(2)*nc_new
-                    Xc_new(j,1:dim) = Xcw_new(j,1:dim)/Xcw_new(j,dim+1)
+                    Xc_new(j,1:d) = Xcw_new(j,1:d)/Xcw_new(j,d+1)
                 end do
 
-                Wc_new(:) = Xcw_new(:,dim+1)
+                Wc_new(:) = Xcw_new(:,d+1)
 
                 call this%set(knot1=this%get_knot(1), knot2=this%get_knot(2), knot3=knot_new, Xc=Xc_new, Wc=Wc_new)
                 deallocate(Xcw, Xcw_new, Xc_new, Wc_new)
 
             else ! B-Spline
 
-                dim = size(this%Xc,2)
+                d = size(this%Xc,2)
 
-                Xc4 = reshape(this%Xc, [this%nc(1),this%nc(2),this%nc(3),dim])
-                Xc4 = reshape(Xc4, [this%nc(3),this%nc(2),this%nc(1),dim], order=[3,2,1,4])
-                Xc = reshape(Xc4,[this%nc(3),this%nc(2)*this%nc(1)*dim])
+                Xc4 = reshape(this%Xc, [this%nc(1),this%nc(2),this%nc(3),d])
+                Xc4 = reshape(Xc4, [this%nc(3),this%nc(2),this%nc(1),d], order=[3,2,1,4])
+                Xc = reshape(Xc4,[this%nc(3),this%nc(2)*this%nc(1)*d])
 
                 call elevate_degree_A_5_9(t, this%knot3, this%degree(3), Xc, nc_new, knot_new, Xc_new)
 
-                Xc4 = reshape(Xc_new, [nc_new,this%nc(2),this%nc(1),dim])
-                Xc4 = reshape(Xc4, [this%nc(1),this%nc(2),nc_new,dim], order=[3,2,1,4])
-                Xc_new = reshape(Xc4,[this%nc(1)*this%nc(2)*nc_new,dim])
+                Xc4 = reshape(Xc_new, [nc_new,this%nc(2),this%nc(1),d])
+                Xc4 = reshape(Xc4, [this%nc(1),this%nc(2),nc_new,d], order=[3,2,1,4])
+                Xc_new = reshape(Xc4,[this%nc(1)*this%nc(2)*nc_new,d])
 
                 call this%set(knot1=this%get_knot(1), knot2=this%get_knot(2), knot3=knot_new, Xc=Xc_new)
 
@@ -2204,7 +2204,7 @@ contains
         integer, intent(in) :: dir
         real(rk), intent(in), contiguous :: Xth(:)
         integer, intent(in), contiguous :: r(:)
-        integer :: k, i, s, dim, j, nc_new, t
+        integer :: k, i, s, d, j, nc_new, t
         real(rk), allocatable :: Xc(:,:), Xcw(:,:), Xcw_new(:,:), Xc_new(:,:), Wc_new(:), knot_new(:)
         real(rk), allocatable :: Xc4(:,:,:,:)
 
@@ -2222,14 +2222,14 @@ contains
                     end if
                     k = k + 1
 
-                    dim = size(this%Xc,2)
-                    allocate(Xcw(size(this%Xc,1),dim+1))
+                    d = size(this%Xc,2)
+                    allocate(Xcw(size(this%Xc,1),d+1))
                     do j = 1, size(this%Xc,1)
-                        Xcw(j,1:dim) = this%Xc(j,1:dim)*this%Wc(j)
+                        Xcw(j,1:d) = this%Xc(j,1:d)*this%Wc(j)
                     end do
-                    Xcw(:,dim+1) = this%Wc(:)
+                    Xcw(:,d+1) = this%Wc(:)
 
-                    Xcw = reshape(Xcw,[this%nc(1),this%nc(2)*this%nc(3)*(dim+1)],order=[1,2])
+                    Xcw = reshape(Xcw,[this%nc(1),this%nc(2)*this%nc(3)*(d+1)],order=[1,2])
 
                     call remove_knots_A_5_8(&
                         this%degree(1),&
@@ -2249,14 +2249,14 @@ contains
                         ! no change
                     else
                         nc_new = size(Xcw_new,1)
-                        Xcw_new = reshape(Xcw_new,[(nc_new)*this%nc(2)*this%nc(3),dim+1],order=[1,2])
+                        Xcw_new = reshape(Xcw_new,[(nc_new)*this%nc(2)*this%nc(3),d+1],order=[1,2])
 
-                        allocate(Xc_new(1:(nc_new)*this%nc(2)*this%nc(3),1:dim))
+                        allocate(Xc_new(1:(nc_new)*this%nc(2)*this%nc(3),1:d))
                         allocate(Wc_new(1:(nc_new)*this%nc(2)*this%nc(3)))
                         do j = 1, (nc_new)*this%nc(2)*this%nc(3)
-                            Xc_new(j,1:dim) = Xcw_new(j,1:dim)/Xcw_new(j,dim+1)
+                            Xc_new(j,1:d) = Xcw_new(j,1:d)/Xcw_new(j,d+1)
                         end do
-                        Wc_new(:) = Xcw_new(:,dim+1)
+                        Wc_new(:) = Xcw_new(:,d+1)
 
                         call this%set(knot1=knot_new, knot2=this%get_knot(2), knot3=this%get_knot(3), Xc=Xc_new, Wc=Wc_new)
                         deallocate(Xcw_new, Xc_new, Wc_new)
@@ -2275,9 +2275,9 @@ contains
                     end if
                     k = k + 1
 
-                    dim = size(this%Xc,2)
+                    d = size(this%Xc,2)
 
-                    Xc = reshape(this%Xc,[this%nc(1),this%nc(2)*this%nc(3)*dim])
+                    Xc = reshape(this%Xc,[this%nc(1),this%nc(2)*this%nc(3)*d])
 
                     call remove_knots_A_5_8(&
                         this%degree(1),&
@@ -2297,7 +2297,7 @@ contains
                         ! no change
                     else
                         nc_new = size(Xcw_new,1)
-                        Xc_new = reshape(Xc_new,[(nc_new)*this%nc(2)*this%nc(3),dim])
+                        Xc_new = reshape(Xc_new,[(nc_new)*this%nc(2)*this%nc(3),d])
 
                         call this%set(knot1=knot_new, knot2=this%get_knot(2), knot3=this%get_knot(3), Xc=Xc_new)
                     end if
@@ -2318,17 +2318,17 @@ contains
                     end if
                     k = k + 1
 
-                    dim = size(this%Xc,2)
-                    allocate(Xcw(size(this%Xc,1),dim+1))
+                    d = size(this%Xc,2)
+                    allocate(Xcw(size(this%Xc,1),d+1))
                     do j = 1, size(this%Xc,1)
-                        Xcw(j,1:dim) = this%Xc(j,1:dim)*this%Wc(j)
+                        Xcw(j,1:d) = this%Xc(j,1:d)*this%Wc(j)
                     end do
 
-                    Xcw(:,dim+1) = this%Wc(:)
+                    Xcw(:,d+1) = this%Wc(:)
 
-                    Xc4 = reshape(Xcw, [this%nc(1),this%nc(2),this%nc(3),dim+1])
-                    Xc4 = reshape(Xc4, [this%nc(2),this%nc(1),this%nc(3),dim+1], order=[2,1,3,4])
-                    Xcw = reshape(Xc4,[this%nc(2),this%nc(1)*this%nc(3)*(dim+1)])
+                    Xc4 = reshape(Xcw, [this%nc(1),this%nc(2),this%nc(3),d+1])
+                    Xc4 = reshape(Xc4, [this%nc(2),this%nc(1),this%nc(3),d+1], order=[2,1,3,4])
+                    Xcw = reshape(Xc4,[this%nc(2),this%nc(1)*this%nc(3)*(d+1)])
 
                     call remove_knots_A_5_8(&
                         this%degree(2),&
@@ -2349,17 +2349,17 @@ contains
                     else
                         nc_new = size(Xcw_new,1)
 
-                        Xc4 = reshape(Xcw_new, [nc_new,this%nc(1),this%nc(3),dim+1])
-                        Xc4 = reshape(Xc4, [this%nc(1),nc_new,this%nc(3),dim+1], order=[2,1,3,4])
-                        Xcw_new = reshape(Xc4,[this%nc(1)*(nc_new)*this%nc(3),dim+1])
+                        Xc4 = reshape(Xcw_new, [nc_new,this%nc(1),this%nc(3),d+1])
+                        Xc4 = reshape(Xc4, [this%nc(1),nc_new,this%nc(3),d+1], order=[2,1,3,4])
+                        Xcw_new = reshape(Xc4,[this%nc(1)*(nc_new)*this%nc(3),d+1])
 
-                        allocate(Xc_new(1:this%nc(1)*(nc_new)*this%nc(3),1:dim))
+                        allocate(Xc_new(1:this%nc(1)*(nc_new)*this%nc(3),1:d))
                         allocate(Wc_new(1:this%nc(1)*(nc_new)*this%nc(3)))
                         do j = 1, this%nc(1)*(nc_new)*this%nc(3)
-                            Xc_new(j,1:dim) = Xcw_new(j,1:dim)/Xcw_new(j,dim+1)
+                            Xc_new(j,1:d) = Xcw_new(j,1:d)/Xcw_new(j,d+1)
                         end do
 
-                        Wc_new(:) = Xcw_new(:,dim+1)
+                        Wc_new(:) = Xcw_new(:,d+1)
 
                         call this%set(knot1=this%get_knot(1), knot2=knot_new, knot3=this%get_knot(3), Xc=Xc_new, Wc=Wc_new)
                         deallocate(Xcw_new, Xc_new, Wc_new)
@@ -2377,11 +2377,11 @@ contains
                     end if
                     k = k + 1
 
-                    dim = size(this%Xc,2)
+                    d = size(this%Xc,2)
 
-                    Xc4 = reshape(this%Xc, [this%nc(1),this%nc(2),this%nc(3),dim])
-                    Xc4 = reshape(Xc4, [this%nc(2),this%nc(1),this%nc(3),dim], order=[2,1,3,4])
-                    Xc = reshape(Xc4, [this%nc(2),this%nc(1)*this%nc(3)*dim])
+                    Xc4 = reshape(this%Xc, [this%nc(1),this%nc(2),this%nc(3),d])
+                    Xc4 = reshape(Xc4, [this%nc(2),this%nc(1),this%nc(3),d], order=[2,1,3,4])
+                    Xc = reshape(Xc4, [this%nc(2),this%nc(1)*this%nc(3)*d])
 
                     call remove_knots_A_5_8(&
                         this%degree(2),&
@@ -2402,9 +2402,9 @@ contains
                     else
                         nc_new = size(Xcw_new,1)
 
-                        Xc4 = reshape(Xc_new, [nc_new,this%nc(1),this%nc(3),dim])
-                        Xc4 = reshape(Xc4, [this%nc(1),nc_new,this%nc(3),dim], order=[2,1,3,4])
-                        Xc_new = reshape(Xc4, [this%nc(1)*(nc_new)*this%nc(3),dim])
+                        Xc4 = reshape(Xc_new, [nc_new,this%nc(1),this%nc(3),d])
+                        Xc4 = reshape(Xc4, [this%nc(1),nc_new,this%nc(3),d], order=[2,1,3,4])
+                        Xc_new = reshape(Xc4, [this%nc(1)*(nc_new)*this%nc(3),d])
 
                         call this%set(knot1=this%get_knot(1), knot2=knot_new, knot3=this%get_knot(3), Xc=Xc_new)
                     end if
@@ -2425,16 +2425,16 @@ contains
                     end if
                     k = k + 1
 
-                    dim = size(this%Xc,2)
-                    allocate(Xcw(size(this%Xc,1),dim+1))
+                    d = size(this%Xc,2)
+                    allocate(Xcw(size(this%Xc,1),d+1))
                     do j = 1, size(this%Xc,1)
-                        Xcw(j,1:dim) = this%Xc(j,1:dim)*this%Wc(j)
+                        Xcw(j,1:d) = this%Xc(j,1:d)*this%Wc(j)
                     end do
-                    Xcw(:,dim+1) = this%Wc(:)
+                    Xcw(:,d+1) = this%Wc(:)
 
-                    Xc4 = reshape(Xcw, [this%nc(1),this%nc(2),this%nc(3),dim+1])
-                    Xc4 = reshape(Xc4, [this%nc(3),this%nc(2),this%nc(1),dim+1], order=[3,2,1,4])
-                    Xcw = reshape(Xc4, [this%nc(3),this%nc(2)*this%nc(1)*(dim+1)])
+                    Xc4 = reshape(Xcw, [this%nc(1),this%nc(2),this%nc(3),d+1])
+                    Xc4 = reshape(Xc4, [this%nc(3),this%nc(2),this%nc(1),d+1], order=[3,2,1,4])
+                    Xcw = reshape(Xc4, [this%nc(3),this%nc(2)*this%nc(1)*(d+1)])
 
                     call remove_knots_A_5_8(&
                         this%degree(3),&
@@ -2455,16 +2455,16 @@ contains
                     else
                         nc_new = size(Xcw_new,1)
 
-                        Xc4 = reshape(Xcw_new, [nc_new,this%nc(2),this%nc(1),dim+1])
-                        Xc4 = reshape(Xc4, [this%nc(1),this%nc(2),nc_new,dim+1], order=[3,2,1,4])
-                        Xcw_new = reshape(Xc4, [this%nc(1)*this%nc(2)*(nc_new),dim+1])
+                        Xc4 = reshape(Xcw_new, [nc_new,this%nc(2),this%nc(1),d+1])
+                        Xc4 = reshape(Xc4, [this%nc(1),this%nc(2),nc_new,d+1], order=[3,2,1,4])
+                        Xcw_new = reshape(Xc4, [this%nc(1)*this%nc(2)*(nc_new),d+1])
 
-                        allocate(Xc_new(1:this%nc(1)*this%nc(2)*(nc_new),1:dim))
+                        allocate(Xc_new(1:this%nc(1)*this%nc(2)*(nc_new),1:d))
                         allocate(Wc_new(1:this%nc(1)*this%nc(2)*(nc_new)))
                         do j = 1, this%nc(1)*this%nc(2)*(nc_new)
-                            Xc_new(j,1:dim) = Xcw_new(j,1:dim)/Xcw_new(j,dim+1)
+                            Xc_new(j,1:d) = Xcw_new(j,1:d)/Xcw_new(j,d+1)
                         end do
-                        Wc_new(:) = Xcw_new(:,dim+1)
+                        Wc_new(:) = Xcw_new(:,d+1)
 
                         call this%set(knot1=this%get_knot(1), knot2=this%get_knot(2), knot3=knot_new, Xc=Xc_new, Wc=Wc_new)
                         deallocate(Xcw_new, Xc_new, Wc_new)
@@ -2482,11 +2482,11 @@ contains
                     end if
                     k = k + 1
 
-                    dim = size(this%Xc,2)
+                    d = size(this%Xc,2)
 
-                    Xc4 = reshape(this%Xc, [this%nc(1),this%nc(2),this%nc(3),dim])
-                    Xc4 = reshape(Xc4, [this%nc(3),this%nc(2),this%nc(1),dim], order=[3,2,1,4])
-                    Xc = reshape(Xc4, [this%nc(3),this%nc(2)*this%nc(1)*dim])
+                    Xc4 = reshape(this%Xc, [this%nc(1),this%nc(2),this%nc(3),d])
+                    Xc4 = reshape(Xc4, [this%nc(3),this%nc(2),this%nc(1),d], order=[3,2,1,4])
+                    Xc = reshape(Xc4, [this%nc(3),this%nc(2)*this%nc(1)*d])
 
                     call remove_knots_A_5_8(&
                         this%degree(3),&
@@ -2507,9 +2507,9 @@ contains
                     else
                         nc_new = size(Xcw_new,1)
 
-                        Xc4 = reshape(Xc_new, [nc_new,this%nc(2),this%nc(1),dim])
-                        Xc4 = reshape(Xc4, [this%nc(1),this%nc(2),nc_new,dim], order=[3,2,1,4])
-                        Xc_new = reshape(Xc4, [this%nc(1)*this%nc(2)*(nc_new),dim])
+                        Xc4 = reshape(Xc_new, [nc_new,this%nc(2),this%nc(1),d])
+                        Xc4 = reshape(Xc4, [this%nc(1),this%nc(2),nc_new,d], order=[3,2,1,4])
+                        Xc_new = reshape(Xc4, [this%nc(1)*this%nc(2)*(nc_new),d])
 
                         call this%set(knot1=this%get_knot(1), knot2=this%get_knot(2), knot3=knot_new, Xc=Xc_new)
                     end if

--- a/src/forcad_nurbs_volume.f90
+++ b/src/forcad_nurbs_volume.f90
@@ -6,7 +6,7 @@ module forcad_nurbs_volume
     use forcad_kinds, only: rk
     use forcad_utils, only: basis_bspline, elemConn_C0, kron, ndgrid, compute_multiplicity, compute_knot_vector, &
         basis_bspline_der, insert_knot_A_5_1, findspan, elevate_degree_A_5_9, hexahedron_Xc, remove_knots_A_5_8, &
-        elemConn_Cn, unique, rotation, det, inv, gauss_leg, export_vtk_legacy
+        elemConn_Cn, unique, rotation, det, inv, gauss_leg, export_vtk_legacy, cmp_Tgc_3d, basis_bspline_2der
 
     implicit none
 
@@ -122,218 +122,31 @@ module forcad_nurbs_volume
     !===============================================================================
 
     interface compute_Xg
-        pure function compute_Xg_nurbs_3d(f_Xt, f_knot1, f_knot2, f_knot3, f_degree, f_nc, f_ng, f_Xc, f_Wc) result(f_Xg)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:,:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:), f_knot3(:)
-            integer, intent(in) :: f_degree(3)
-            integer, intent(in) :: f_nc(3)
-            integer, intent(in) :: f_ng(3)
-            real(rk), intent(in), contiguous :: f_Xc(:,:)
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable :: f_Xg(:,:)
-        end function
-
-        pure function compute_Xg_bspline_3d(f_Xt, f_knot1, f_knot2, f_knot3, f_degree, f_nc, f_ng, f_Xc) result(f_Xg)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:,:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:), f_knot3(:)
-            integer, intent(in) :: f_degree(3)
-            integer, intent(in) :: f_nc(3)
-            integer, intent(in) :: f_ng(3)
-            real(rk), intent(in), contiguous :: f_Xc(:,:)
-            real(rk), allocatable :: f_Xg(:,:)
-        end function
-
-        pure function compute_Xg_nurbs_3d_1point(f_Xt, f_knot1, f_knot2, f_knot3, f_degree, f_nc, f_Xc, f_Wc) result(f_Xg)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:), f_knot3(:)
-            integer, intent(in) :: f_degree(3)
-            integer, intent(in) :: f_nc(3)
-            real(rk), intent(in), contiguous :: f_Xc(:,:)
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable :: f_Xg(:)
-        end function
-
-        pure function compute_Xg_bspline_3d_1point(f_Xt, f_knot1, f_knot2, f_knot3, f_degree, f_nc, f_Xc) result(f_Xg)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:), f_knot3(:)
-            integer, intent(in) :: f_degree(3)
-            integer, intent(in) :: f_nc(3)
-            real(rk), intent(in), contiguous :: f_Xc(:,:)
-            real(rk), allocatable :: f_Xg(:)
-        end function
-    end interface
-
-    interface compute_dTgc
-        pure subroutine compute_dTgc_nurbs_3d_vector(f_Xt, f_knot1, f_knot2, f_knot3, f_degree, f_nc, f_ng, f_Wc, f_dTgc, f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:,:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:), f_knot3(:)
-            integer, intent(in) :: f_degree(3)
-            integer, intent(in) :: f_nc(3)
-            integer, intent(in) :: f_ng(3)
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:,:)
-        end subroutine
-
-        pure subroutine compute_dTgc_bspline_3d_vector(f_Xt, f_knot1, f_knot2, f_knot3, f_degree, f_nc, f_ng, f_dTgc, f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:,:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:), f_knot3(:)
-            integer, intent(in) :: f_degree(3)
-            integer, intent(in) :: f_nc(3)
-            integer, intent(in) :: f_ng(3)
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:,:)
-        end subroutine
-
-        pure subroutine compute_dTgc_nurbs_3d_scalar(f_Xt, f_knot1, f_knot2, f_knot3, f_degree, f_nc, f_Wc, f_dTgc, f_Tgc, f_elem)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:), f_knot3(:)
-            integer, intent(in) :: f_degree(3)
-            integer, intent(in) :: f_nc(3)
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:)
-            integer, intent(in), optional :: f_elem(:)
-        end subroutine
-
-        pure subroutine compute_dTgc_bspline_3d_scalar(f_Xt, f_knot1, f_knot2, f_knot3, f_degree, f_nc, f_dTgc, f_Tgc, f_elem)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:), f_knot3(:)
-            integer, intent(in) :: f_degree(3)
-            integer, intent(in) :: f_nc(3)
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:)
-            integer, intent(in), optional :: f_elem(:)
-        end subroutine
-    end interface
-
-    interface compute_d2Tgc
-        pure subroutine compute_d2Tgc_nurbs_3d_vector(&
-            f_Xt, f_knot1, f_knot2, f_knot3, f_degree, f_nc, f_ng, f_Wc, f_d2Tgc, f_dTgc, f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:,:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:), f_knot3(:)
-            integer, intent(in) :: f_degree(3)
-            integer, intent(in) :: f_nc(3)
-            integer, intent(in) :: f_ng(3)
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable, intent(out) :: f_d2Tgc(:,:,:)
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:,:)
-        end subroutine
-
-        pure subroutine compute_d2Tgc_bspline_3d_vector(&
-            f_Xt, f_knot1, f_knot2, f_knot3, f_degree, f_nc, f_ng, f_d2Tgc, f_dTgc, f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:,:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:), f_knot3(:)
-            integer, intent(in) :: f_degree(3)
-            integer, intent(in) :: f_nc(3)
-            integer, intent(in) :: f_ng(3)
-            real(rk), allocatable, intent(out) :: f_d2Tgc(:,:,:)
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:,:)
-        end subroutine
-
-        pure subroutine compute_d2Tgc_nurbs_3d_scalar(f_Xt, f_knot1, f_knot2, f_knot3, f_degree, f_nc, f_Wc, f_d2Tgc, f_dTgc, f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:), f_knot3(:)
-            integer, intent(in) :: f_degree(3)
-            integer, intent(in) :: f_nc(3)
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable, intent(out) :: f_d2Tgc(:,:)
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:)
-        end subroutine
-
-        pure subroutine compute_d2Tgc_bspline_3d_scalar(f_Xt, f_knot1, f_knot2, f_knot3, f_degree, f_nc, f_d2Tgc, f_dTgc, f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:), f_knot3(:)
-            integer, intent(in) :: f_degree(3)
-            integer, intent(in) :: f_nc(3)
-            real(rk), allocatable, intent(out) :: f_d2Tgc(:,:)
-            real(rk), allocatable, intent(out) :: f_dTgc(:,:)
-            real(rk), allocatable, intent(out) :: f_Tgc(:)
-        end subroutine
+        module procedure compute_Xg_nurbs_3d
+        module procedure compute_Xg_bspline_3d
+        module procedure compute_Xg_nurbs_3d_1point
+        module procedure compute_Xg_bspline_3d_1point
     end interface
 
     interface compute_Tgc
-        pure function compute_Tgc_nurbs_3d_vector(f_Xt, f_knot1, f_knot2, f_knot3, f_degree, f_nc, f_ng, f_Wc) result(f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:,:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:), f_knot3(:)
-            integer, intent(in) :: f_degree(3)
-            integer, intent(in) :: f_nc(3)
-            integer, intent(in) :: f_ng(3)
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable :: f_Tgc(:,:)
-        end function
-
-        pure function compute_Tgc_bspline_3d_vector(f_Xt, f_knot1, f_knot2, f_knot3, f_degree, f_nc, f_ng) result(f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:,:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:), f_knot3(:)
-            integer, intent(in) :: f_degree(3)
-            integer, intent(in) :: f_nc(3)
-            integer, intent(in) :: f_ng(3)
-            real(rk), allocatable :: f_Tgc(:,:)
-        end function
-
-        pure function compute_Tgc_nurbs_3d_scalar(f_Xt, f_knot1, f_knot2, f_knot3, f_degree, f_nc, f_Wc) result(f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:), f_knot3(:)
-            integer, intent(in) :: f_degree(3)
-            integer, intent(in) :: f_nc(3)
-            real(rk), intent(in), contiguous :: f_Wc(:)
-            real(rk), allocatable :: f_Tgc(:)
-        end function
-
-        pure function compute_Tgc_bspline_3d_scalar(f_Xt, f_knot1, f_knot2, f_knot3, f_degree, f_nc) result(f_Tgc)
-            import :: rk
-            implicit none
-            real(rk), intent(in), contiguous :: f_Xt(:)
-            real(rk), intent(in), contiguous :: f_knot1(:), f_knot2(:), f_knot3(:)
-            integer, intent(in) :: f_degree(3)
-            integer, intent(in) :: f_nc(3)
-            real(rk), allocatable :: f_Tgc(:)
-        end function
+        module procedure compute_Tgc_nurbs_3d_vector
+        module procedure compute_Tgc_bspline_3d_vector
+        module procedure compute_Tgc_nurbs_3d_scalar
+        module procedure compute_Tgc_bspline_3d_scalar
     end interface
 
-    interface
-        pure function nearest_point_help_3d(f_ng, f_Xg, f_point_Xg) result(f_distances)
-            import :: rk
-            implicit none
-            integer, intent(in) :: f_ng(3)
-            real(rk), intent(in), contiguous :: f_Xg(:,:)
-            real(rk), intent(in), contiguous :: f_point_Xg(:)
-            real(rk), allocatable :: f_distances(:)
-        end function
+    interface compute_dTgc
+        module procedure compute_dTgc_nurbs_3d_vector
+        module procedure compute_dTgc_bspline_3d_vector
+        module procedure compute_dTgc_nurbs_3d_scalar
+        module procedure compute_dTgc_bspline_3d_scalar
+    end interface
+
+    interface compute_d2Tgc
+        module procedure compute_d2Tgc_nurbs_3d_vector
+        module procedure compute_d2Tgc_bspline_3d_vector
+        module procedure compute_d2Tgc_nurbs_3d_scalar
+        module procedure compute_d2Tgc_bspline_3d_scalar
     end interface
 
 contains
@@ -3344,200 +3157,417 @@ contains
     end subroutine
     !===============================================================================
 
-end module forcad_nurbs_volume
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Xg_nurbs_3d(Xt, knot1, knot2, knot3, degree, nc, ng, Xc, Wc) result(Xg)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function cmp_Tgc_3d(Xti, knot1, knot2, knot3, nc, degree, Wc) result(Tgc)
+        real(rk), intent(in), contiguous :: Xti(:)
+        real(rk), intent(in), contiguous :: knot1(:)
+        real(rk), intent(in), contiguous :: knot2(:)
+        real(rk), intent(in), contiguous :: knot3(:)
+        integer, intent(in) :: degree(3), nc(3)
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk) :: Tgc(nc(1)*nc(2)*nc(3))
+        real(rk) :: tmp
+        integer :: i
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:,:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
-    integer, intent(in) :: degree(3)
-    integer, intent(in) :: nc(3)
-    integer, intent(in) :: ng(3)
-    real(rk), intent(in), contiguous :: Xc(:,:)
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable :: Xg(:,:)
-    real(rk), allocatable :: Tgc(:)
-    integer :: i
-
-    allocate(Xg(ng(1)*ng(2)*ng(3), size(Xc,2)))
-    allocate(Tgc(nc(1)*nc(2)*nc(3)))
-
-    !$omp parallel do private(Tgc)
-    do i = 1, ng(1)*ng(2)*ng(3)
-        Tgc = kron(basis_bspline(Xt(i,3), knot3, nc(3), degree(3)),&
+        Tgc = kron(basis_bspline(Xti(3), knot3, nc(3), degree(3)),&
             kron(&
-            basis_bspline(Xt(i,2), knot2, nc(2), degree(2)),&
-            basis_bspline(Xt(i,1), knot1, nc(1), degree(1))))
+            basis_bspline(Xti(2), knot2, nc(2), degree(2)),&
+            basis_bspline(Xti(1), knot1, nc(1), degree(1))))
+        tmp = dot_product(Tgc, Wc)
+        do concurrent (i = 1: nc(1)*nc(2)*nc(3))
+           Tgc(i) = (Tgc(i) * Wc(i)) / tmp
+        end do
+    end function
+    !===============================================================================
+
+
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Xg_nurbs_3d(Xt, knot1, knot2, knot3, degree, nc, ng, Xc, Wc) result(Xg)
+        real(rk), intent(in), contiguous :: Xt(:,:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
+        integer, intent(in) :: degree(3)
+        integer, intent(in) :: nc(3)
+        integer, intent(in) :: ng(3)
+        real(rk), intent(in), contiguous :: Xc(:,:)
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable :: Xg(:,:)
+        integer :: i
+
+        allocate(Xg(ng(1)*ng(2)*ng(3), size(Xc,2)))
+        do concurrent (i = 1: ng(1)*ng(2)*ng(3))
+            Xg(i,:) = matmul(cmp_Tgc_3d(Xt(i,:), knot1, knot2, knot3, nc, degree, Wc), Xc)
+        end do
+    end function
+    !===============================================================================
+
+
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Xg_nurbs_3d_1point(Xt, knot1, knot2, knot3, degree, nc, Xc, Wc) result(Xg)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
+        integer, intent(in) :: degree(3)
+        integer, intent(in) :: nc(3)
+        real(rk), intent(in), contiguous :: Xc(:,:)
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable :: Xg(:)
+        real(rk), allocatable :: Tgc(:)
+
+        allocate(Xg(size(Xc,2)))
+        allocate(Tgc(nc(1)*nc(2)*nc(3)))
+
+        Tgc = kron(basis_bspline(Xt(3), knot3, nc(3), degree(3)),&
+            kron(&
+            basis_bspline(Xt(2), knot2, nc(2), degree(2)),&
+            basis_bspline(Xt(1), knot1, nc(1), degree(1))))
         Tgc = Tgc*(Wc/(dot_product(Tgc,Wc)))
-        Xg(i,:) = matmul(Tgc, Xc)
-    end do
-    !$omp end parallel do
-end function
-!===============================================================================
+        Xg = matmul(Tgc, Xc)
+    end function
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Xg_nurbs_3d_1point(Xt, knot1, knot2, knot3, degree, nc, Xc, Wc) result(Xg)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Xg_bspline_3d(Xt, knot1, knot2, knot3, degree, nc, ng, Xc) result(Xg)
+        real(rk), intent(in), contiguous :: Xt(:,:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
+        integer, intent(in) :: degree(3)
+        integer, intent(in) :: nc(3)
+        integer, intent(in) :: ng(3)
+        real(rk), intent(in), contiguous :: Xc(:,:)
+        real(rk), allocatable :: Xg(:,:)
+        integer :: i
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
-    integer, intent(in) :: degree(3)
-    integer, intent(in) :: nc(3)
-    real(rk), intent(in), contiguous :: Xc(:,:)
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable :: Xg(:)
-    real(rk), allocatable :: Tgc(:)
-
-    allocate(Xg(size(Xc,2)))
-    allocate(Tgc(nc(1)*nc(2)*nc(3)))
-
-    Tgc = kron(basis_bspline(Xt(3), knot3, nc(3), degree(3)),&
-        kron(&
-        basis_bspline(Xt(2), knot2, nc(2), degree(2)),&
-        basis_bspline(Xt(1), knot1, nc(1), degree(1))))
-    Tgc = Tgc*(Wc/(dot_product(Tgc,Wc)))
-    Xg = matmul(Tgc, Xc)
-end function
-!===============================================================================
+        allocate(Xg(ng(1)*ng(2)*ng(3), size(Xc,2)))
+        do concurrent (i = 1: ng(1)*ng(2)*ng(3))
+            Xg(i,:) = matmul(kron(basis_bspline(Xt(i,3), knot3, nc(3), degree(3)), kron(&
+                basis_bspline(Xt(i,2), knot2, nc(2), degree(2)),&
+                basis_bspline(Xt(i,1), knot1, nc(1), degree(1)))),&
+                Xc)
+        end do
+    end function
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Xg_bspline_3d(Xt, knot1, knot2, knot3, degree, nc, ng, Xc) result(Xg)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Xg_bspline_3d_1point(Xt, knot1, knot2, knot3, degree, nc, Xc) result(Xg)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
+        integer, intent(in) :: degree(3)
+        integer, intent(in) :: nc(3)
+        real(rk), intent(in), contiguous :: Xc(:,:)
+        real(rk), allocatable :: Xg(:)
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:,:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
-    integer, intent(in) :: degree(3)
-    integer, intent(in) :: nc(3)
-    integer, intent(in) :: ng(3)
-    real(rk), intent(in), contiguous :: Xc(:,:)
-    real(rk), allocatable :: Xg(:,:)
-    integer :: i
-
-    allocate(Xg(ng(1)*ng(2)*ng(3), size(Xc,2)))
-    !$omp parallel do
-    do i = 1, ng(1)*ng(2)*ng(3)
-        Xg(i,:) = matmul(kron(basis_bspline(Xt(i,3), knot3, nc(3), degree(3)), kron(&
-            basis_bspline(Xt(i,2), knot2, nc(2), degree(2)),&
-            basis_bspline(Xt(i,1), knot1, nc(1), degree(1)))),&
+        allocate(Xg(size(Xc,2)))
+        Xg = matmul(kron(basis_bspline(Xt(3), knot3, nc(3), degree(3)), kron(&
+            basis_bspline(Xt(2), knot2, nc(2), degree(2)),&
+            basis_bspline(Xt(1), knot1, nc(1), degree(1)))),&
             Xc)
-    end do
-    !$omp end parallel do
-end function
-!===============================================================================
+    end function
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Xg_bspline_3d_1point(Xt, knot1, knot2, knot3, degree, nc, Xc) result(Xg)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_dTgc_nurbs_3d_vector(Xt, knot1, knot2, knot3, degree, nc, ng, Wc, dTgc, Tgc)
+        real(rk), intent(in), contiguous :: Xt(:,:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
+        integer, intent(in) :: degree(3)
+        integer, intent(in) :: nc(3)
+        integer, intent(in) :: ng(3)
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable, intent(out) :: dTgc(:,:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:,:)
+        real(rk) :: dB1(nc(1)), dB2(nc(2)), dB3(nc(3))
+        real(rk) :: B1(nc(1)), B2(nc(2)), B3(nc(3))
+        real(rk), allocatable :: dBi(:,:), Bi(:)
+        integer :: i
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
-    integer, intent(in) :: degree(3)
-    integer, intent(in) :: nc(3)
-    real(rk), intent(in), contiguous :: Xc(:,:)
-    real(rk), allocatable :: Xg(:)
+        allocate(dTgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3), 3))
+        allocate(Tgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3)))
+        allocate(Bi(nc(1)*nc(2)*nc(3)), dBi(nc(1)*nc(2)*nc(3), 3))
+        do concurrent (i = 1: size(Xt, 1))
+            call basis_bspline_der(Xt(i,1), knot1, nc(1), degree(1), dB1, B1)
+            call basis_bspline_der(Xt(i,2), knot2, nc(2), degree(2), dB2, B2)
+            call basis_bspline_der(Xt(i,3), knot3, nc(3), degree(3), dB3, B3)
 
-    allocate(Xg(size(Xc,2)))
-    Xg = matmul(kron(basis_bspline(Xt(3), knot3, nc(3), degree(3)), kron(&
-        basis_bspline(Xt(2), knot2, nc(2), degree(2)),&
-        basis_bspline(Xt(1), knot1, nc(1), degree(1)))),&
-        Xc)
-end function
-!===============================================================================
+            Bi  = kron( B3, kron( B2,  B1))
+            Tgc(i,:) = Bi*(Wc/(dot_product(Bi,Wc)))
 
+            dBi(:,1) = kron(kron(B3,B2),dB1)
+            dBi(:,2) = kron(kron(B3,dB2),B1)
+            dBi(:,3) = kron(kron(dB3,B2),B1)
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_dTgc_nurbs_3d_vector(Xt, knot1, knot2, knot3, degree, nc, ng, Wc, dTgc, Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_der, kron
-
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:,:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
-    integer, intent(in) :: degree(3)
-    integer, intent(in) :: nc(3)
-    integer, intent(in) :: ng(3)
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable, intent(out) :: dTgc(:,:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:,:)
-    real(rk), allocatable :: dBi(:,:), dB1(:), dB2(:), dB3(:)
-    real(rk), allocatable :: Bi(:), B1(:), B2(:), B3(:)
-    integer :: i
-
-    allocate(dTgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3), 3))
-    allocate(Tgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3)))
-    allocate(Bi(nc(1)*nc(2)*nc(3)), dBi(nc(1)*nc(2)*nc(3), 3))
-    do i = 1, size(Xt, 1)
-        call basis_bspline_der(Xt(i,1), knot1, nc(1), degree(1), dB1, B1)
-        call basis_bspline_der(Xt(i,2), knot2, nc(2), degree(2), dB2, B2)
-        call basis_bspline_der(Xt(i,3), knot3, nc(3), degree(3), dB3, B3)
-
-        Bi  = kron( B3, kron( B2,  B1))
-        Tgc(i,:) = Bi*(Wc/(dot_product(Bi,Wc)))
-
-        dBi(:,1) = kron(kron(B3,B2),dB1)
-        dBi(:,2) = kron(kron(B3,dB2),B1)
-        dBi(:,3) = kron(kron(dB3,B2),B1)
-
-        dTgc(i,:,1) = ( dBi(:,1)*Wc - Tgc(i,:)*dot_product(dBi(:,1),Wc) ) / dot_product(Bi,Wc)
-        dTgc(i,:,2) = ( dBi(:,2)*Wc - Tgc(i,:)*dot_product(dBi(:,2),Wc) ) / dot_product(Bi,Wc)
-        dTgc(i,:,3) = ( dBi(:,3)*Wc - Tgc(i,:)*dot_product(dBi(:,3),Wc) ) / dot_product(Bi,Wc)
-    end do
-end subroutine
-!===============================================================================
+            dTgc(i,:,1) = ( dBi(:,1)*Wc - Tgc(i,:)*dot_product(dBi(:,1),Wc) ) / dot_product(Bi,Wc)
+            dTgc(i,:,2) = ( dBi(:,2)*Wc - Tgc(i,:)*dot_product(dBi(:,2),Wc) ) / dot_product(Bi,Wc)
+            dTgc(i,:,3) = ( dBi(:,3)*Wc - Tgc(i,:)*dot_product(dBi(:,3),Wc) ) / dot_product(Bi,Wc)
+        end do
+    end subroutine
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_dTgc_nurbs_3d_scalar(Xt, knot1, knot2, knot3, degree, nc, Wc, dTgc, Tgc, elem)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_der, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_dTgc_nurbs_3d_scalar(Xt, knot1, knot2, knot3, degree, nc, Wc, dTgc, Tgc, elem)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
+        integer, intent(in) :: degree(3)
+        integer, intent(in) :: nc(3)
+        real(rk), intent(in), contiguous :: Wc(:)
+        integer, intent(in), optional :: elem(:)
+        real(rk), allocatable, intent(out) :: dTgc(:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:)
+        real(rk) :: dB1(nc(1)), dB2(nc(2)), dB3(nc(3))
+        real(rk) :: B1(nc(1)), B2(nc(2)), B3(nc(3))
+        real(rk), allocatable :: dBi(:,:), Bi(:)
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
-    integer, intent(in) :: degree(3)
-    integer, intent(in) :: nc(3)
-    real(rk), intent(in), contiguous :: Wc(:)
-    integer, intent(in), optional :: elem(:)
-    real(rk), allocatable, intent(out) :: dTgc(:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:)
-    real(rk), allocatable :: dB1(:), dB2(:), dB3(:), dBi(:,:)
-    real(rk), allocatable :: B1(:), B2(:), B3(:), Bi(:)
+        call basis_bspline_der(Xt(1), knot1, nc(1), degree(1), dB1, B1)
+        call basis_bspline_der(Xt(2), knot2, nc(2), degree(2), dB2, B2)
+        call basis_bspline_der(Xt(3), knot3, nc(3), degree(3), dB3, B3)
 
-    call basis_bspline_der(Xt(1), knot1, nc(1), degree(1), dB1, B1)
-    call basis_bspline_der(Xt(2), knot2, nc(2), degree(2), dB2, B2)
-    call basis_bspline_der(Xt(3), knot3, nc(3), degree(3), dB3, B3)
+        if (.not. present(elem)) then
+            allocate(dTgc(nc(1)*nc(2)*nc(3), 3))
+            allocate(Tgc(nc(1)*nc(2)*nc(3)))
+            allocate(dBi(nc(1)*nc(2)*nc(3), 3), Bi(nc(1)*nc(2)*nc(3)))
 
-    if (.not. present(elem)) then
+            Bi = kron( B3, kron( B2,  B1))
+            Tgc = Bi*(Wc/(dot_product(Bi,Wc)))
+
+            dBi(:,1) = kron(kron(B3,B2),dB1)
+            dBi(:,2) = kron(kron(B3,dB2),B1)
+            dBi(:,3) = kron(kron(dB3,B2),B1)
+
+            dTgc(:,1) = ( dBi(:,1)*Wc - Tgc*dot_product(dBi(:,1),Wc) ) / dot_product(Bi,Wc)
+            dTgc(:,2) = ( dBi(:,2)*Wc - Tgc*dot_product(dBi(:,2),Wc) ) / dot_product(Bi,Wc)
+            dTgc(:,3) = ( dBi(:,3)*Wc - Tgc*dot_product(dBi(:,3),Wc) ) / dot_product(Bi,Wc)
+        else
+            allocate(dTgc(size(elem), 3))
+            allocate(Tgc(size(elem)))
+            allocate(dBi(size(elem), 3), Bi(size(elem)))
+
+            associate(Biall => kron( B3, kron( B2,  B1)))
+                Bi = Biall(elem)
+                Tgc = Bi*(Wc(elem)/(dot_product(Bi,Wc(elem))))
+            end associate
+
+            associate(dB1all => kron(kron(B3,B2),dB1), dB2all => kron(kron(B3,dB2),B1), dB3all => kron(kron(dB3,B2),B1))
+                dBi(:,1) = dB1all(elem)
+                dBi(:,2) = dB2all(elem)
+                dBi(:,3) = dB3all(elem)
+            end associate
+
+            dTgc(:,1) = ( dBi(:,1)*Wc(elem) - Tgc*dot_product(dBi(:,1),Wc(elem)) ) / dot_product(Bi,Wc(elem))
+            dTgc(:,2) = ( dBi(:,2)*Wc(elem) - Tgc*dot_product(dBi(:,2),Wc(elem)) ) / dot_product(Bi,Wc(elem))
+            dTgc(:,3) = ( dBi(:,3)*Wc(elem) - Tgc*dot_product(dBi(:,3),Wc(elem)) ) / dot_product(Bi,Wc(elem))
+        end if
+    end subroutine
+    !===============================================================================
+
+
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_dTgc_bspline_3d_vector(Xt, knot1, knot2, knot3, degree, nc, ng, dTgc, Tgc)
+        real(rk), intent(in), contiguous :: Xt(:,:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
+        integer, intent(in) :: degree(3)
+        integer, intent(in) :: nc(3)
+        integer, intent(in) :: ng(3)
+        real(rk), allocatable, intent(out) :: dTgc(:,:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:,:)
+        real(rk) :: dB1(nc(1)), dB2(nc(2)), dB3(nc(3))
+        real(rk) :: B1(nc(1)), B2(nc(2)), B3(nc(3))
+        integer :: i
+
+        allocate(dTgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3), 3))
+        allocate(Tgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3)))
+
+        do concurrent (i = 1: size(Xt, 1))
+            call basis_bspline_der(Xt(i,1), knot1, nc(1), degree(1), dB1, B1)
+            call basis_bspline_der(Xt(i,2), knot2, nc(2), degree(2), dB2, B2)
+            call basis_bspline_der(Xt(i,3), knot3, nc(3), degree(3), dB3, B3)
+
+            Tgc(i,:) = kron(B3, kron(B2, B1))
+
+            dTgc(i,:,1) = kron(kron(B3,B2),dB1)
+            dTgc(i,:,2) = kron(kron(B3,dB2),B1)
+            dTgc(i,:,3) = kron(kron(dB3,B2),B1)
+        end do
+
+    end subroutine
+    !===============================================================================
+
+
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_dTgc_bspline_3d_scalar(Xt, knot1, knot2, knot3, degree, nc, dTgc, Tgc, elem)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
+        integer, intent(in) :: degree(3)
+        integer, intent(in) :: nc(3)
+        integer, intent(in), optional :: elem(:)
+        real(rk), allocatable, intent(out) :: dTgc(:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:)
+        real(rk) :: dB1(nc(1)), dB2(nc(2)), dB3(nc(3))
+        real(rk) :: B1(nc(1)), B2(nc(2)), B3(nc(3))
+
+        call basis_bspline_der(Xt(1), knot1, nc(1), degree(1), dB1, B1)
+        call basis_bspline_der(Xt(2), knot2, nc(2), degree(2), dB2, B2)
+        call basis_bspline_der(Xt(3), knot3, nc(3), degree(3), dB3, B3)
+
+        if (.not. present(elem)) then
+            allocate(dTgc(nc(1)*nc(2)*nc(3), 3))
+            allocate(Tgc(nc(1)*nc(2)*nc(3)))
+
+            Tgc = kron(B3, kron(B2, B1))
+            dTgc(:,1) = kron(kron(B3,B2),dB1)
+            dTgc(:,2) = kron(kron(B3,dB2),B1)
+            dTgc(:,3) = kron(kron(dB3,B2),B1)
+        else
+            allocate(dTgc(size(elem), 3))
+            allocate(Tgc(size(elem)))
+
+            associate(B => kron(B3, kron(B2, B1)))
+                Tgc = B(elem)
+            end associate
+
+            associate(dB1 => kron(kron(B3,B2),dB1), dB2 => kron(kron(B3,dB2),B1), dB3 => kron(kron(dB3,B2),B1))
+                dTgc(:,1) = dB1(elem)
+                dTgc(:,2) = dB2(elem)
+                dTgc(:,3) = dB3(elem)
+            end associate
+        end if
+    end subroutine
+    !===============================================================================
+
+
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_d2Tgc_nurbs_3d_vector(Xt, knot1, knot2, knot3, degree, nc, ng, Wc, d2Tgc, dTgc, Tgc)
+        real(rk), intent(in), contiguous :: Xt(:,:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
+        integer, intent(in) :: degree(3)
+        integer, intent(in) :: nc(3)
+        integer, intent(in) :: ng(3)
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable, intent(out) :: d2Tgc(:,:,:)
+        real(rk), allocatable, intent(out) :: dTgc(:,:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:,:)
+        real(rk) :: d2B1(nc(1)), d2B2(nc(2)), d2B3(nc(3))
+        real(rk) :: dB1(nc(1)), dB2(nc(2)), dB3(nc(3))
+        real(rk) :: B1(nc(1)), B2(nc(2)), B3(nc(3))
+        real(rk), allocatable :: Tgci(:), dTgci(:)
+        real(rk), allocatable :: d2Bi(:,:), dBi(:,:), Bi(:)
+        integer :: i
+
+        allocate(Bi(nc(1)*nc(2)*nc(3)), dBi(nc(1)*nc(2)*nc(3), 3), d2Bi(3*nc(1)*nc(2)*nc(3), 3))
+
+        allocate(Tgci(nc(1)*nc(2)*nc(3)), dTgci(nc(1)*nc(2)*nc(3)))
+        allocate(d2Tgc(ng(1)*ng(2)*ng(3), 3*nc(1)*nc(2)*nc(3), 3))
+        allocate(dTgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3), 3))
+        allocate(Tgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3)))
+        do concurrent (i = 1: size(Xt, 1))
+            call basis_bspline_2der(Xt(i,1), knot1, nc(1), degree(1), d2B1, dB1, B1)
+            call basis_bspline_2der(Xt(i,2), knot2, nc(2), degree(2), d2B2, dB2, B2)
+            call basis_bspline_2der(Xt(i,3), knot3, nc(3), degree(3), d2B3, dB3, B3)
+
+            Bi = kron(B3, kron(B2, B1))
+
+            Tgc(i,:) = Bi*(Wc/(dot_product(Bi,Wc)))
+
+            dBi(:,1) = kron(kron(B3,B2),dB1)
+            dBi(:,2) = kron(kron(B3,dB2),B1)
+            dBi(:,3) = kron(kron(dB3,B2),B1)
+
+            dTgc(i,:,1) = ( dBi(:,1)*Wc - Tgc(i,:)*dot_product(dBi(:,1),Wc) ) / dot_product(Bi,Wc)
+            dTgc(i,:,2) = ( dBi(:,2)*Wc - Tgc(i,:)*dot_product(dBi(:,2),Wc) ) / dot_product(Bi,Wc)
+            dTgc(i,:,3) = ( dBi(:,3)*Wc - Tgc(i,:)*dot_product(dBi(:,3),Wc) ) / dot_product(Bi,Wc)
+
+            d2Bi(1:nc(1)*nc(2)*nc(3)                       ,1) = kron(kron(B3,B2),d2B1)
+            d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,1) = kron(kron(B3,dB2),dB1)
+            d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,1) = kron(kron(dB3,B2),dB1)
+            d2Bi(1:nc(1)*nc(2)*nc(3)                       ,2) = kron(kron(B3,dB2),dB1)
+            d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,2) = kron(kron(B3,d2B2),B1)
+            d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,2) = kron(kron(dB3,dB2),B1)
+            d2Bi(1:nc(1)*nc(2)*nc(3)                       ,3) = kron(kron(dB3,B2),dB1)
+            d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,3) = kron(kron(dB3,dB2),B1)
+            d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,3) = kron(kron(d2B3,B2),B1)
+
+            d2Tgc(i, 1:nc(1)*nc(2)*nc(3)                       ,1) = (d2Bi(1:nc(1)*nc(2)*nc(3)                       ,1)*Wc &
+                - 2.0_rk*dTgc(i, :,1)*dot_product(dBi(:,1),Wc)                                  &
+                - Tgc(i,:)*dot_product(d2Bi(1:nc(1)*nc(2)*nc(3)                       ,1),Wc)) / dot_product(Bi,Wc)
+            d2Tgc(i, nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,1) = (d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,1)*Wc &
+                - dTgc(i, :,1)*dot_product(dBi(:,2),Wc) - dTgc(i, :,2)*dot_product(dBi(:,1),Wc) &
+                - Tgc(i,:)*dot_product(d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,1),Wc)) / dot_product(Bi,Wc)
+            d2Tgc(i, 2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,1) = (d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,1)*Wc &
+                - dTgc(i, :,1)*dot_product(dBi(:,3),Wc) - dTgc(i, :,3)*dot_product(dBi(:,1),Wc) &
+                - Tgc(i,:)*dot_product(d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,1),Wc)) / dot_product(Bi,Wc)
+            d2Tgc(i, 1:nc(1)*nc(2)*nc(3)                       ,2) = (d2Bi(1:nc(1)*nc(2)*nc(3)                       ,2)*Wc &
+                - dTgc(i, :,1)*dot_product(dBi(:,2),Wc) - dTgc(i, :,2)*dot_product(dBi(:,1),Wc) &
+                - Tgc(i,:)*dot_product(d2Bi(1:nc(1)*nc(2)*nc(3)                       ,2),Wc)) / dot_product(Bi,Wc)
+            d2Tgc(i, nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,2) = (d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,2)*Wc &
+                - 2.0_rk*dTgc(i, :,2)*dot_product(dBi(:,2),Wc)                                  &
+                - Tgc(i,:)*dot_product(d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,2),Wc)) / dot_product(Bi,Wc)
+            d2Tgc(i, 2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,2) = (d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,2)*Wc &
+                - dTgc(i, :,2)*dot_product(dBi(:,3),Wc) - dTgc(i, :,3)*dot_product(dBi(:,2),Wc) &
+                - Tgc(i,:)*dot_product(d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,2),Wc)) / dot_product(Bi,Wc)
+            d2Tgc(i, 1:nc(1)*nc(2)*nc(3)                       ,3) = (d2Bi(1:nc(1)*nc(2)*nc(3)                       ,3)*Wc &
+                - dTgc(i, :,1)*dot_product(dBi(:,3),Wc) - dTgc(i, :,3)*dot_product(dBi(:,1),Wc) &
+                - Tgc(i,:)*dot_product(d2Bi(1:nc(1)*nc(2)*nc(3)                       ,3),Wc)) / dot_product(Bi,Wc)
+            d2Tgc(i, nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,3) = (d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,3)*Wc &
+                - dTgc(i, :,2)*dot_product(dBi(:,3),Wc) - dTgc(i, :,3)*dot_product(dBi(:,2),Wc) &
+                - Tgc(i,:)*dot_product(d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,3),Wc)) / dot_product(Bi,Wc)
+            d2Tgc(i, 2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,3) = (d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,3)*Wc &
+                - 2.0_rk*dTgc(i, :,3)*dot_product(dBi(:,3),Wc)                                  &
+                - Tgc(i,:)*dot_product(d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,3),Wc)) / dot_product(Bi,Wc)
+        end do
+    end subroutine
+    !===============================================================================
+
+
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_d2Tgc_nurbs_3d_scalar(Xt, knot1, knot2, knot3, degree, nc, Wc, d2Tgc, dTgc, Tgc)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
+        integer, intent(in) :: degree(3)
+        integer, intent(in) :: nc(3)
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable, intent(out) :: d2Tgc(:,:)
+        real(rk), allocatable, intent(out) :: dTgc(:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:)
+        real(rk) :: d2B1(nc(1)), d2B2(nc(2)), d2B3(nc(3))
+        real(rk) :: dB1(nc(1)), dB2(nc(2)), dB3(nc(3))
+        real(rk) :: B1(nc(1)), B2(nc(2)), B3(nc(3))
+        real(rk), allocatable :: d2Bi(:,:), dBi(:,:), Bi(:)
+
+
+        allocate(Bi(nc(1)*nc(2)*nc(3)), dBi(nc(1)*nc(2)*nc(3), 3), d2Bi(3*nc(1)*nc(2)*nc(3), 3))
+
+        allocate(d2Tgc(3*nc(1)*nc(2)*nc(3), 3))
         allocate(dTgc(nc(1)*nc(2)*nc(3), 3))
         allocate(Tgc(nc(1)*nc(2)*nc(3)))
-        allocate(dBi(nc(1)*nc(2)*nc(3), 3), Bi(nc(1)*nc(2)*nc(3)))
 
-        Bi = kron( B3, kron( B2,  B1))
+        call basis_bspline_2der(Xt(1), knot1, nc(1), degree(1), d2B1, dB1, B1)
+        call basis_bspline_2der(Xt(2), knot2, nc(2), degree(2), d2B2, dB2, B2)
+        call basis_bspline_2der(Xt(3), knot3, nc(3), degree(3), d2B3, dB3, B3)
+
+        Bi = kron(B3, kron(B2, B1))
+
         Tgc = Bi*(Wc/(dot_product(Bi,Wc)))
 
         dBi(:,1) = kron(kron(B3,B2),dB1)
@@ -3547,164 +3577,6 @@ impure subroutine compute_dTgc_nurbs_3d_scalar(Xt, knot1, knot2, knot3, degree, 
         dTgc(:,1) = ( dBi(:,1)*Wc - Tgc*dot_product(dBi(:,1),Wc) ) / dot_product(Bi,Wc)
         dTgc(:,2) = ( dBi(:,2)*Wc - Tgc*dot_product(dBi(:,2),Wc) ) / dot_product(Bi,Wc)
         dTgc(:,3) = ( dBi(:,3)*Wc - Tgc*dot_product(dBi(:,3),Wc) ) / dot_product(Bi,Wc)
-    else
-        allocate(dTgc(size(elem), 3))
-        allocate(Tgc(size(elem)))
-        allocate(dBi(size(elem), 3), Bi(size(elem)))
-
-        associate(Biall => kron( B3, kron( B2,  B1)))
-            Bi = Biall(elem)
-            Tgc = Bi*(Wc(elem)/(dot_product(Bi,Wc(elem))))
-        end associate
-
-        associate(dB1all => kron(kron(B3,B2),dB1), dB2all => kron(kron(B3,dB2),B1), dB3all => kron(kron(dB3,B2),B1))
-            dBi(:,1) = dB1all(elem)
-            dBi(:,2) = dB2all(elem)
-            dBi(:,3) = dB3all(elem)
-        end associate
-
-        dTgc(:,1) = ( dBi(:,1)*Wc(elem) - Tgc*dot_product(dBi(:,1),Wc(elem)) ) / dot_product(Bi,Wc(elem))
-        dTgc(:,2) = ( dBi(:,2)*Wc(elem) - Tgc*dot_product(dBi(:,2),Wc(elem)) ) / dot_product(Bi,Wc(elem))
-        dTgc(:,3) = ( dBi(:,3)*Wc(elem) - Tgc*dot_product(dBi(:,3),Wc(elem)) ) / dot_product(Bi,Wc(elem))
-    end if
-end subroutine
-!===============================================================================
-
-
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_dTgc_bspline_3d_vector(Xt, knot1, knot2, knot3, degree, nc, ng, dTgc, Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_der, kron
-
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:,:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
-    integer, intent(in) :: degree(3)
-    integer, intent(in) :: nc(3)
-    integer, intent(in) :: ng(3)
-    real(rk), allocatable, intent(out) :: dTgc(:,:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:,:)
-    real(rk), allocatable :: dB1(:), dB2(:), dB3(:)
-    real(rk), allocatable :: B1(:), B2(:), B3(:)
-    integer :: i
-
-    allocate(dTgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3), 3))
-    allocate(Tgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3)))
-
-    do i = 1, size(Xt, 1)
-        call basis_bspline_der(Xt(i,1), knot1, nc(1), degree(1), dB1, B1)
-        call basis_bspline_der(Xt(i,2), knot2, nc(2), degree(2), dB2, B2)
-        call basis_bspline_der(Xt(i,3), knot3, nc(3), degree(3), dB3, B3)
-
-        Tgc(i,:) = kron(B3, kron(B2, B1))
-
-        dTgc(i,:,1) = kron(kron(B3,B2),dB1)
-        dTgc(i,:,2) = kron(kron(B3,dB2),B1)
-        dTgc(i,:,3) = kron(kron(dB3,B2),B1)
-    end do
-
-end subroutine
-!===============================================================================
-
-
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_dTgc_bspline_3d_scalar(Xt, knot1, knot2, knot3, degree, nc, dTgc, Tgc, elem)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_der, kron
-
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
-    integer, intent(in) :: degree(3)
-    integer, intent(in) :: nc(3)
-    integer, intent(in), optional :: elem(:)
-    real(rk), allocatable, intent(out) :: dTgc(:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:)
-    real(rk), allocatable :: dB1(:), dB2(:), dB3(:)
-    real(rk), allocatable :: B1(:), B2(:), B3(:)
-
-    call basis_bspline_der(Xt(1), knot1, nc(1), degree(1), dB1, B1)
-    call basis_bspline_der(Xt(2), knot2, nc(2), degree(2), dB2, B2)
-    call basis_bspline_der(Xt(3), knot3, nc(3), degree(3), dB3, B3)
-
-    if (.not. present(elem)) then
-        allocate(dTgc(nc(1)*nc(2)*nc(3), 3))
-        allocate(Tgc(nc(1)*nc(2)*nc(3)))
-
-        Tgc = kron(B3, kron(B2, B1))
-        dTgc(:,1) = kron(kron(B3,B2),dB1)
-        dTgc(:,2) = kron(kron(B3,dB2),B1)
-        dTgc(:,3) = kron(kron(dB3,B2),B1)
-    else
-        allocate(dTgc(size(elem), 3))
-        allocate(Tgc(size(elem)))
-
-        associate(B => kron(B3, kron(B2, B1)))
-            Tgc = B(elem)
-        end associate
-
-        associate(dB1 => kron(kron(B3,B2),dB1), dB2 => kron(kron(B3,dB2),B1), dB3 => kron(kron(dB3,B2),B1))
-            dTgc(:,1) = dB1(elem)
-            dTgc(:,2) = dB2(elem)
-            dTgc(:,3) = dB3(elem)
-        end associate
-    end if
-end subroutine
-!===============================================================================
-
-
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_d2Tgc_nurbs_3d_vector(Xt, knot1, knot2, knot3, degree, nc, ng, Wc, d2Tgc, dTgc, Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_2der, kron
-
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:,:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
-    integer, intent(in) :: degree(3)
-    integer, intent(in) :: nc(3)
-    integer, intent(in) :: ng(3)
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable, intent(out) :: d2Tgc(:,:,:)
-    real(rk), allocatable, intent(out) :: dTgc(:,:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:,:)
-    real(rk), allocatable :: d2Bi(:,:), d2B1(:), d2B2(:), d2B3(:)
-    real(rk), allocatable :: dBi(:,:), dB1(:), dB2(:), dB3(:)
-    real(rk), allocatable :: Bi(:), B1(:), B2(:), B3(:)
-    real(rk), allocatable :: Tgci(:), dTgci(:)
-    integer :: i
-
-    allocate(B1(nc(1)), B2(nc(2)), B3(nc(3)))
-    allocate(dB1(nc(1)), dB2(nc(2)), dB3(nc(3)))
-    allocate(d2B1(nc(1)), d2B2(nc(2)), d2B3(nc(3)))
-    allocate(Bi(nc(1)*nc(2)*nc(3)), dBi(nc(1)*nc(2)*nc(3), 3), d2Bi(3*nc(1)*nc(2)*nc(3), 3))
-
-    allocate(Tgci(nc(1)*nc(2)*nc(3)), dTgci(nc(1)*nc(2)*nc(3)))
-    allocate(d2Tgc(ng(1)*ng(2)*ng(3), 3*nc(1)*nc(2)*nc(3), 3))
-    allocate(dTgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3), 3))
-    allocate(Tgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3)))
-    do i = 1, size(Xt, 1)
-        call basis_bspline_2der(Xt(i,1), knot1, nc(1), degree(1), d2B1, dB1, B1)
-        call basis_bspline_2der(Xt(i,2), knot2, nc(2), degree(2), d2B2, dB2, B2)
-        call basis_bspline_2der(Xt(i,3), knot3, nc(3), degree(3), d2B3, dB3, B3)
-
-        Bi = kron(B3, kron(B2, B1))
-
-        Tgc(i,:) = Bi*(Wc/(dot_product(Bi,Wc)))
-
-        dBi(:,1) = kron(kron(B3,B2),dB1)
-        dBi(:,2) = kron(kron(B3,dB2),B1)
-        dBi(:,3) = kron(kron(dB3,B2),B1)
-
-        dTgc(i,:,1) = ( dBi(:,1)*Wc - Tgc(i,:)*dot_product(dBi(:,1),Wc) ) / dot_product(Bi,Wc)
-        dTgc(i,:,2) = ( dBi(:,2)*Wc - Tgc(i,:)*dot_product(dBi(:,2),Wc) ) / dot_product(Bi,Wc)
-        dTgc(i,:,3) = ( dBi(:,3)*Wc - Tgc(i,:)*dot_product(dBi(:,3),Wc) ) / dot_product(Bi,Wc)
 
         d2Bi(1:nc(1)*nc(2)*nc(3)                       ,1) = kron(kron(B3,B2),d2B1)
         d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,1) = kron(kron(B3,dB2),dB1)
@@ -3716,340 +3588,225 @@ impure subroutine compute_d2Tgc_nurbs_3d_vector(Xt, knot1, knot2, knot3, degree,
         d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,3) = kron(kron(dB3,dB2),B1)
         d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,3) = kron(kron(d2B3,B2),B1)
 
-        d2Tgc(i, 1:nc(1)*nc(2)*nc(3)                       ,1) = (d2Bi(1:nc(1)*nc(2)*nc(3)                       ,1)*Wc &
-            - 2.0_rk*dTgc(i, :,1)*dot_product(dBi(:,1),Wc)                                  &
-            - Tgc(i,:)*dot_product(d2Bi(1:nc(1)*nc(2)*nc(3)                       ,1),Wc)) / dot_product(Bi,Wc)
-        d2Tgc(i, nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,1) = (d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,1)*Wc &
-            - dTgc(i, :,1)*dot_product(dBi(:,2),Wc) - dTgc(i, :,2)*dot_product(dBi(:,1),Wc) &
-            - Tgc(i,:)*dot_product(d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,1),Wc)) / dot_product(Bi,Wc)
-        d2Tgc(i, 2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,1) = (d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,1)*Wc &
-            - dTgc(i, :,1)*dot_product(dBi(:,3),Wc) - dTgc(i, :,3)*dot_product(dBi(:,1),Wc) &
-            - Tgc(i,:)*dot_product(d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,1),Wc)) / dot_product(Bi,Wc)
-        d2Tgc(i, 1:nc(1)*nc(2)*nc(3)                       ,2) = (d2Bi(1:nc(1)*nc(2)*nc(3)                       ,2)*Wc &
-            - dTgc(i, :,1)*dot_product(dBi(:,2),Wc) - dTgc(i, :,2)*dot_product(dBi(:,1),Wc) &
-            - Tgc(i,:)*dot_product(d2Bi(1:nc(1)*nc(2)*nc(3)                       ,2),Wc)) / dot_product(Bi,Wc)
-        d2Tgc(i, nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,2) = (d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,2)*Wc &
-            - 2.0_rk*dTgc(i, :,2)*dot_product(dBi(:,2),Wc)                                  &
-            - Tgc(i,:)*dot_product(d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,2),Wc)) / dot_product(Bi,Wc)
-        d2Tgc(i, 2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,2) = (d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,2)*Wc &
-            - dTgc(i, :,2)*dot_product(dBi(:,3),Wc) - dTgc(i, :,3)*dot_product(dBi(:,2),Wc) &
-            - Tgc(i,:)*dot_product(d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,2),Wc)) / dot_product(Bi,Wc)
-        d2Tgc(i, 1:nc(1)*nc(2)*nc(3)                       ,3) = (d2Bi(1:nc(1)*nc(2)*nc(3)                       ,3)*Wc &
-            - dTgc(i, :,1)*dot_product(dBi(:,3),Wc) - dTgc(i, :,3)*dot_product(dBi(:,1),Wc) &
-            - Tgc(i,:)*dot_product(d2Bi(1:nc(1)*nc(2)*nc(3)                       ,3),Wc)) / dot_product(Bi,Wc)
-        d2Tgc(i, nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,3) = (d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,3)*Wc &
-            - dTgc(i, :,2)*dot_product(dBi(:,3),Wc) - dTgc(i, :,3)*dot_product(dBi(:,2),Wc) &
-            - Tgc(i,:)*dot_product(d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,3),Wc)) / dot_product(Bi,Wc)
-        d2Tgc(i, 2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,3) = (d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,3)*Wc &
-            - 2.0_rk*dTgc(i, :,3)*dot_product(dBi(:,3),Wc)                                  &
-            - Tgc(i,:)*dot_product(d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,3),Wc)) / dot_product(Bi,Wc)
-    end do
-end subroutine
-!===============================================================================
+        d2Tgc(1:nc(1)*nc(2)*nc(3)                       ,1) = (d2Bi(1:nc(1)*nc(2)*nc(3)                       ,1)*Wc &
+            - 2.0_rk*dTgc(:,1)*dot_product(dBi(:,1),Wc)                               &
+            - Tgc*dot_product(d2Bi(1:nc(1)*nc(2)*nc(3)                       ,1),Wc)) / dot_product(Bi,Wc)
+        d2Tgc(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,1) = (d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,1)*Wc &
+            - dTgc(:,1)*dot_product(dBi(:,2),Wc) - dTgc(:,2)*dot_product(dBi(:,1),Wc) &
+            - Tgc*dot_product(d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,1),Wc)) / dot_product(Bi,Wc)
+        d2Tgc(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,1) = (d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,1)*Wc &
+            - dTgc(:,1)*dot_product(dBi(:,3),Wc) - dTgc(:,3)*dot_product(dBi(:,1),Wc) &
+            - Tgc*dot_product(d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,1),Wc)) / dot_product(Bi,Wc)
+        d2Tgc(1:nc(1)*nc(2)*nc(3)                       ,2) = (d2Bi(1:nc(1)*nc(2)*nc(3)                       ,2)*Wc &
+            - dTgc(:,1)*dot_product(dBi(:,2),Wc) - dTgc(:,2)*dot_product(dBi(:,1),Wc) &
+            - Tgc*dot_product(d2Bi(1:nc(1)*nc(2)*nc(3)                       ,2),Wc)) / dot_product(Bi,Wc)
+        d2Tgc(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,2) = (d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,2)*Wc &
+            - 2.0_rk*dTgc(:,2)*dot_product(dBi(:,2),Wc)                               &
+            - Tgc*dot_product(d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,2),Wc)) / dot_product(Bi,Wc)
+        d2Tgc(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,2) = (d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,2)*Wc &
+            - dTgc(:,2)*dot_product(dBi(:,3),Wc) - dTgc(:,3)*dot_product(dBi(:,2),Wc) &
+            - Tgc*dot_product(d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,2),Wc)) / dot_product(Bi,Wc)
+        d2Tgc(1:nc(1)*nc(2)*nc(3)                       ,3) = (d2Bi(1:nc(1)*nc(2)*nc(3)                       ,3)*Wc &
+            - dTgc(:,1)*dot_product(dBi(:,3),Wc) - dTgc(:,3)*dot_product(dBi(:,1),Wc) &
+            - Tgc*dot_product(d2Bi(1:nc(1)*nc(2)*nc(3)                       ,3),Wc)) / dot_product(Bi,Wc)
+        d2Tgc(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,3) = (d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,3)*Wc &
+            - dTgc(:,2)*dot_product(dBi(:,3),Wc) - dTgc(:,3)*dot_product(dBi(:,2),Wc) &
+            - Tgc*dot_product(d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,3),Wc)) / dot_product(Bi,Wc)
+        d2Tgc(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,3) = (d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,3)*Wc &
+            - 2.0_rk*dTgc(:,3)*dot_product(dBi(:,3),Wc)                               &
+            - Tgc*dot_product(d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,3),Wc)) / dot_product(Bi,Wc)
+    end subroutine
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_d2Tgc_nurbs_3d_scalar(Xt, knot1, knot2, knot3, degree, nc, Wc, d2Tgc, dTgc, Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_2der, kron
-
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
-    integer, intent(in) :: degree(3)
-    integer, intent(in) :: nc(3)
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable, intent(out) :: d2Tgc(:,:)
-    real(rk), allocatable, intent(out) :: dTgc(:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:)
-    real(rk), allocatable :: d2Bi(:,:), d2B1(:), d2B2(:), d2B3(:)
-    real(rk), allocatable :: dBi(:,:), dB1(:), dB2(:), dB3(:)
-    real(rk), allocatable :: Bi(:), B1(:), B2(:), B3(:)
-
-    allocate(B1(nc(1)), B2(nc(2)), B3(nc(3)))
-    allocate(dB1(nc(1)), dB2(nc(2)), dB3(nc(3)))
-    allocate(d2B1(nc(1)), d2B2(nc(2)), d2B3(nc(3)))
-    allocate(Bi(nc(1)*nc(2)*nc(3)), dBi(nc(1)*nc(2)*nc(3), 3), d2Bi(3*nc(1)*nc(2)*nc(3), 3))
-
-    allocate(d2Tgc(3*nc(1)*nc(2)*nc(3), 3))
-    allocate(dTgc(nc(1)*nc(2)*nc(3), 3))
-    allocate(Tgc(nc(1)*nc(2)*nc(3)))
-
-    call basis_bspline_2der(Xt(1), knot1, nc(1), degree(1), d2B1, dB1, B1)
-    call basis_bspline_2der(Xt(2), knot2, nc(2), degree(2), d2B2, dB2, B2)
-    call basis_bspline_2der(Xt(3), knot3, nc(3), degree(3), d2B3, dB3, B3)
-
-    Bi = kron(B3, kron(B2, B1))
-
-    Tgc = Bi*(Wc/(dot_product(Bi,Wc)))
-
-    dBi(:,1) = kron(kron(B3,B2),dB1)
-    dBi(:,2) = kron(kron(B3,dB2),B1)
-    dBi(:,3) = kron(kron(dB3,B2),B1)
-
-    dTgc(:,1) = ( dBi(:,1)*Wc - Tgc*dot_product(dBi(:,1),Wc) ) / dot_product(Bi,Wc)
-    dTgc(:,2) = ( dBi(:,2)*Wc - Tgc*dot_product(dBi(:,2),Wc) ) / dot_product(Bi,Wc)
-    dTgc(:,3) = ( dBi(:,3)*Wc - Tgc*dot_product(dBi(:,3),Wc) ) / dot_product(Bi,Wc)
-
-    d2Bi(1:nc(1)*nc(2)*nc(3)                       ,1) = kron(kron(B3,B2),d2B1)
-    d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,1) = kron(kron(B3,dB2),dB1)
-    d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,1) = kron(kron(dB3,B2),dB1)
-    d2Bi(1:nc(1)*nc(2)*nc(3)                       ,2) = kron(kron(B3,dB2),dB1)
-    d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,2) = kron(kron(B3,d2B2),B1)
-    d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,2) = kron(kron(dB3,dB2),B1)
-    d2Bi(1:nc(1)*nc(2)*nc(3)                       ,3) = kron(kron(dB3,B2),dB1)
-    d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,3) = kron(kron(dB3,dB2),B1)
-    d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,3) = kron(kron(d2B3,B2),B1)
-
-    d2Tgc(1:nc(1)*nc(2)*nc(3)                       ,1) = (d2Bi(1:nc(1)*nc(2)*nc(3)                       ,1)*Wc &
-        - 2.0_rk*dTgc(:,1)*dot_product(dBi(:,1),Wc)                               &
-        - Tgc*dot_product(d2Bi(1:nc(1)*nc(2)*nc(3)                       ,1),Wc)) / dot_product(Bi,Wc)
-    d2Tgc(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,1) = (d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,1)*Wc &
-        - dTgc(:,1)*dot_product(dBi(:,2),Wc) - dTgc(:,2)*dot_product(dBi(:,1),Wc) &
-        - Tgc*dot_product(d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,1),Wc)) / dot_product(Bi,Wc)
-    d2Tgc(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,1) = (d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,1)*Wc &
-        - dTgc(:,1)*dot_product(dBi(:,3),Wc) - dTgc(:,3)*dot_product(dBi(:,1),Wc) &
-        - Tgc*dot_product(d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,1),Wc)) / dot_product(Bi,Wc)
-    d2Tgc(1:nc(1)*nc(2)*nc(3)                       ,2) = (d2Bi(1:nc(1)*nc(2)*nc(3)                       ,2)*Wc &
-        - dTgc(:,1)*dot_product(dBi(:,2),Wc) - dTgc(:,2)*dot_product(dBi(:,1),Wc) &
-        - Tgc*dot_product(d2Bi(1:nc(1)*nc(2)*nc(3)                       ,2),Wc)) / dot_product(Bi,Wc)
-    d2Tgc(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,2) = (d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,2)*Wc &
-        - 2.0_rk*dTgc(:,2)*dot_product(dBi(:,2),Wc)                               &
-        - Tgc*dot_product(d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,2),Wc)) / dot_product(Bi,Wc)
-    d2Tgc(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,2) = (d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,2)*Wc &
-        - dTgc(:,2)*dot_product(dBi(:,3),Wc) - dTgc(:,3)*dot_product(dBi(:,2),Wc) &
-        - Tgc*dot_product(d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,2),Wc)) / dot_product(Bi,Wc)
-    d2Tgc(1:nc(1)*nc(2)*nc(3)                       ,3) = (d2Bi(1:nc(1)*nc(2)*nc(3)                       ,3)*Wc &
-        - dTgc(:,1)*dot_product(dBi(:,3),Wc) - dTgc(:,3)*dot_product(dBi(:,1),Wc) &
-        - Tgc*dot_product(d2Bi(1:nc(1)*nc(2)*nc(3)                       ,3),Wc)) / dot_product(Bi,Wc)
-    d2Tgc(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,3) = (d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,3)*Wc &
-        - dTgc(:,2)*dot_product(dBi(:,3),Wc) - dTgc(:,3)*dot_product(dBi(:,2),Wc) &
-        - Tgc*dot_product(d2Bi(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,3),Wc)) / dot_product(Bi,Wc)
-    d2Tgc(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,3) = (d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,3)*Wc &
-        - 2.0_rk*dTgc(:,3)*dot_product(dBi(:,3),Wc)                               &
-        - Tgc*dot_product(d2Bi(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,3),Wc)) / dot_product(Bi,Wc)
-end subroutine
-!===============================================================================
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_d2Tgc_bspline_3d_vector(Xt, knot1, knot2, knot3, degree, nc, ng, d2Tgc, dTgc, Tgc)
+        real(rk), intent(in), contiguous :: Xt(:,:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
+        integer, intent(in) :: degree(3)
+        integer, intent(in) :: nc(3)
+        integer, intent(in) :: ng(3)
+        real(rk), allocatable, intent(out) :: d2Tgc(:,:,:)
+        real(rk), allocatable, intent(out) :: dTgc(:,:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:,:)
+        integer :: i
+        real(rk) :: d2B1(nc(1)), d2B2(nc(2)), d2B3(nc(3))
+        real(rk) :: dB1(nc(1)), dB2(nc(2)), dB3(nc(3))
+        real(rk) :: B1(nc(1)), B2(nc(2)), B3(nc(3))
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_d2Tgc_bspline_3d_vector(Xt, knot1, knot2, knot3, degree, nc, ng, d2Tgc, dTgc, Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_2der, kron
+        allocate(d2Tgc(ng(1)*ng(2)*ng(3), 3*nc(1)*nc(2)*nc(3), 3))
+        allocate(dTgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3), 3))
+        allocate(Tgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3)))
+        do concurrent (i = 1: size(Xt, 1))
+            call basis_bspline_2der(Xt(i,1), knot1, nc(1), degree(1), d2B1, dB1, B1)
+            call basis_bspline_2der(Xt(i,2), knot2, nc(2), degree(2), d2B2, dB2, B2)
+            call basis_bspline_2der(Xt(i,3), knot3, nc(3), degree(3), d2B3, dB3, B3)
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:,:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
-    integer, intent(in) :: degree(3)
-    integer, intent(in) :: nc(3)
-    integer, intent(in) :: ng(3)
-    real(rk), allocatable, intent(out) :: d2Tgc(:,:,:)
-    real(rk), allocatable, intent(out) :: dTgc(:,:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:,:)
-    real(rk), allocatable :: d2B1(:), d2B2(:), d2B3(:)
-    real(rk), allocatable :: dB1(:), dB2(:), dB3(:)
-    real(rk), allocatable :: B1(:), B2(:), B3(:)
-    integer :: i
+            Tgc(i,:) = kron(B3, kron(B2, B1))
 
-    allocate(d2Tgc(ng(1)*ng(2)*ng(3), 3*nc(1)*nc(2)*nc(3), 3))
-    allocate(dTgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3), 3))
-    allocate(Tgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3)))
-    do i = 1, size(Xt, 1)
-        call basis_bspline_2der(Xt(i,1), knot1, nc(1), degree(1), d2B1, dB1, B1)
-        call basis_bspline_2der(Xt(i,2), knot2, nc(2), degree(2), d2B2, dB2, B2)
-        call basis_bspline_2der(Xt(i,3), knot3, nc(3), degree(3), d2B3, dB3, B3)
+            dTgc(i,:,1) = kron(kron(B3,B2),dB1)
+            dTgc(i,:,2) = kron(kron(B3,dB2),B1)
+            dTgc(i,:,3) = kron(kron(dB3,B2),B1)
 
-        Tgc(i,:) = kron(B3, kron(B2, B1))
-
-        dTgc(i,:,1) = kron(kron(B3,B2),dB1)
-        dTgc(i,:,2) = kron(kron(B3,dB2),B1)
-        dTgc(i,:,3) = kron(kron(dB3,B2),B1)
-
-        d2Tgc(i,1:nc(1)*nc(2)*nc(3)                       ,1) = kron(kron(B3,B2),d2B1)
-        d2Tgc(i,nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,1) = kron(kron(B3,dB2),dB1)
-        d2Tgc(i,2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,1) = kron(kron(dB3,B2),dB1)
-        d2Tgc(i,1:nc(1)*nc(2)*nc(3)                       ,2) = kron(kron(B3,dB2),dB1)
-        d2Tgc(i,nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,2) = kron(kron(B3,d2B2),B1)
-        d2Tgc(i,2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,2) = kron(kron(dB3,dB2),B1)
-        d2Tgc(i,1:nc(1)*nc(2)*nc(3)                       ,3) = kron(kron(dB3,B2),dB1)
-        d2Tgc(i,nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,3) = kron(kron(dB3,dB2),B1)
-        d2Tgc(i,2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,3) = kron(kron(d2B3,B2),B1)
-    end do
-end subroutine
-!===============================================================================
+            d2Tgc(i,1:nc(1)*nc(2)*nc(3)                       ,1) = kron(kron(B3,B2),d2B1)
+            d2Tgc(i,nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,1) = kron(kron(B3,dB2),dB1)
+            d2Tgc(i,2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,1) = kron(kron(dB3,B2),dB1)
+            d2Tgc(i,1:nc(1)*nc(2)*nc(3)                       ,2) = kron(kron(B3,dB2),dB1)
+            d2Tgc(i,nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,2) = kron(kron(B3,d2B2),B1)
+            d2Tgc(i,2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,2) = kron(kron(dB3,dB2),B1)
+            d2Tgc(i,1:nc(1)*nc(2)*nc(3)                       ,3) = kron(kron(dB3,B2),dB1)
+            d2Tgc(i,nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,3) = kron(kron(dB3,dB2),B1)
+            d2Tgc(i,2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,3) = kron(kron(d2B3,B2),B1)
+        end do
+    end subroutine
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure subroutine compute_d2Tgc_bspline_3d_scalar(Xt, knot1, knot2, knot3, degree, nc, d2Tgc, dTgc, Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline_2der, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure subroutine compute_d2Tgc_bspline_3d_scalar(Xt, knot1, knot2, knot3, degree, nc, d2Tgc, dTgc, Tgc)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
+        integer, intent(in) :: degree(3)
+        integer, intent(in) :: nc(3)
+        real(rk), allocatable, intent(out) :: d2Tgc(:,:)
+        real(rk), allocatable, intent(out) :: dTgc(:,:)
+        real(rk), allocatable, intent(out) :: Tgc(:)
+        real(rk) :: d2B1(nc(1)), d2B2(nc(2)), d2B3(nc(3))
+        real(rk) :: dB1(nc(1)), dB2(nc(2)), dB3(nc(3))
+        real(rk) :: B1(nc(1)), B2(nc(2)), B3(nc(3))
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
-    integer, intent(in) :: degree(3)
-    integer, intent(in) :: nc(3)
-    real(rk), allocatable, intent(out) :: d2Tgc(:,:)
-    real(rk), allocatable, intent(out) :: dTgc(:,:)
-    real(rk), allocatable, intent(out) :: Tgc(:)
-    real(rk), allocatable :: d2B1(:), d2B2(:), d2B3(:)
-    real(rk), allocatable :: dB1(:), dB2(:), dB3(:)
-    real(rk), allocatable :: B1(:), B2(:), B3(:)
+        allocate(d2Tgc(3*nc(1)*nc(2)*nc(3), 3))
+        allocate(dTgc(nc(1)*nc(2)*nc(3), 3))
+        allocate(Tgc(nc(1)*nc(2)*nc(3)))
+        call basis_bspline_2der(Xt(1), knot1, nc(1), degree(1), d2B1, dB1, B1)
+        call basis_bspline_2der(Xt(2), knot2, nc(2), degree(2), d2B2, dB2, B2)
+        call basis_bspline_2der(Xt(3), knot3, nc(3), degree(3), d2B3, dB3, B3)
 
-    allocate(d2Tgc(3*nc(1)*nc(2)*nc(3), 3))
-    allocate(dTgc(nc(1)*nc(2)*nc(3), 3))
-    allocate(Tgc(nc(1)*nc(2)*nc(3)))
-    call basis_bspline_2der(Xt(1), knot1, nc(1), degree(1), d2B1, dB1, B1)
-    call basis_bspline_2der(Xt(2), knot2, nc(2), degree(2), d2B2, dB2, B2)
-    call basis_bspline_2der(Xt(3), knot3, nc(3), degree(3), d2B3, dB3, B3)
+        Tgc = kron(B3, kron(B2, B1))
 
-    Tgc = kron(B3, kron(B2, B1))
+        dTgc(:,1) = kron(kron(B3,B2),dB1)
+        dTgc(:,2) = kron(kron(B3,dB2),B1)
+        dTgc(:,3) = kron(kron(dB3,B2),B1)
 
-    dTgc(:,1) = kron(kron(B3,B2),dB1)
-    dTgc(:,2) = kron(kron(B3,dB2),B1)
-    dTgc(:,3) = kron(kron(dB3,B2),B1)
-
-    d2Tgc(1:nc(1)*nc(2)*nc(3)                       ,1) = kron(kron(B3,B2),d2B1)
-    d2Tgc(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,1) = kron(kron(B3,dB2),dB1)
-    d2Tgc(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,1) = kron(kron(dB3,B2),dB1)
-    d2Tgc(1:nc(1)*nc(2)*nc(3)                       ,2) = kron(kron(B3,dB2),dB1)
-    d2Tgc(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,2) = kron(kron(B3,d2B2),B1)
-    d2Tgc(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,2) = kron(kron(dB3,dB2),B1)
-    d2Tgc(1:nc(1)*nc(2)*nc(3)                       ,3) = kron(kron(dB3,B2),dB1)
-    d2Tgc(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,3) = kron(kron(dB3,dB2),B1)
-    d2Tgc(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,3) = kron(kron(d2B3,B2),B1)
-end subroutine
-!===============================================================================
+        d2Tgc(1:nc(1)*nc(2)*nc(3)                       ,1) = kron(kron(B3,B2),d2B1)
+        d2Tgc(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,1) = kron(kron(B3,dB2),dB1)
+        d2Tgc(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,1) = kron(kron(dB3,B2),dB1)
+        d2Tgc(1:nc(1)*nc(2)*nc(3)                       ,2) = kron(kron(B3,dB2),dB1)
+        d2Tgc(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,2) = kron(kron(B3,d2B2),B1)
+        d2Tgc(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,2) = kron(kron(dB3,dB2),B1)
+        d2Tgc(1:nc(1)*nc(2)*nc(3)                       ,3) = kron(kron(dB3,B2),dB1)
+        d2Tgc(nc(1)*nc(2)*nc(3)+1:2*nc(1)*nc(2)*nc(3)   ,3) = kron(kron(dB3,dB2),B1)
+        d2Tgc(2*nc(1)*nc(2)*nc(3)+1:3*nc(1)*nc(2)*nc(3) ,3) = kron(kron(d2B3,B2),B1)
+    end subroutine
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Tgc_nurbs_3d_vector(Xt, knot1, knot2, knot3, degree, nc, ng, Wc) result(Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Tgc_nurbs_3d_vector(Xt, knot1, knot2, knot3, degree, nc, ng, Wc) result(Tgc)
+        real(rk), intent(in), contiguous :: Xt(:,:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
+        integer, intent(in) :: degree(3)
+        integer, intent(in) :: nc(3)
+        integer, intent(in) :: ng(3)
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable :: Tgc(:,:)
+        real(rk), allocatable :: Tgci(:)
+        integer :: i
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:,:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
-    integer, intent(in) :: degree(3)
-    integer, intent(in) :: nc(3)
-    integer, intent(in) :: ng(3)
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable :: Tgc(:,:)
-    real(rk), allocatable :: Tgci(:)
-    integer :: i
-
-    allocate(Tgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3)))
-    allocate(Tgci(nc(1)*nc(2)*nc(3)))
-    !$omp parallel do private(Tgci)
-    do i = 1, size(Xt, 1)
-        Tgci = kron(basis_bspline(Xt(i,3), knot3, nc(3), degree(3)), kron(&
-            basis_bspline(Xt(i,2), knot2, nc(2), degree(2)),&
-            basis_bspline(Xt(i,1), knot1, nc(1), degree(1))))
-        Tgc(i,:) = Tgci*(Wc/(dot_product(Tgci,Wc)))
-    end do
-    !$omp end parallel do
-end function
-!===============================================================================
+        allocate(Tgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3)))
+        allocate(Tgci(nc(1)*nc(2)*nc(3)))
+        do concurrent (i = 1: size(Xt, 1))
+            Tgci = kron(basis_bspline(Xt(i,3), knot3, nc(3), degree(3)), kron(&
+                basis_bspline(Xt(i,2), knot2, nc(2), degree(2)),&
+                basis_bspline(Xt(i,1), knot1, nc(1), degree(1))))
+            Tgc(i,:) = Tgci*(Wc/(dot_product(Tgci,Wc)))
+        end do
+    end function
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Tgc_nurbs_3d_scalar(Xt, knot1, knot2, knot3, degree, nc, Wc) result(Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Tgc_nurbs_3d_scalar(Xt, knot1, knot2, knot3, degree, nc, Wc) result(Tgc)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
+        integer, intent(in) :: degree(3)
+        integer, intent(in) :: nc(3)
+        real(rk), intent(in), contiguous :: Wc(:)
+        real(rk), allocatable :: Tgc(:)
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
-    integer, intent(in) :: degree(3)
-    integer, intent(in) :: nc(3)
-    real(rk), intent(in), contiguous :: Wc(:)
-    real(rk), allocatable :: Tgc(:)
-
-    allocate(Tgc(nc(1)*nc(2)*nc(3)))
-    Tgc = kron(basis_bspline(Xt(3), knot3, nc(3), degree(3)), kron(&
-        basis_bspline(Xt(2), knot2, nc(2), degree(2)),&
-        basis_bspline(Xt(1), knot1, nc(1), degree(1))))
-    Tgc = Tgc*(Wc/(dot_product(Tgc,Wc)))
-end function
-!===============================================================================
+        allocate(Tgc(nc(1)*nc(2)*nc(3)))
+        Tgc = kron(basis_bspline(Xt(3), knot3, nc(3), degree(3)), kron(&
+            basis_bspline(Xt(2), knot2, nc(2), degree(2)),&
+            basis_bspline(Xt(1), knot1, nc(1), degree(1))))
+        Tgc = Tgc*(Wc/(dot_product(Tgc,Wc)))
+    end function
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Tgc_bspline_3d_vector(Xt, knot1, knot2, knot3, degree, nc, ng) result(Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Tgc_bspline_3d_vector(Xt, knot1, knot2, knot3, degree, nc, ng) result(Tgc)
+        real(rk), intent(in), contiguous :: Xt(:,:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
+        integer, intent(in) :: degree(3)
+        integer, intent(in) :: nc(3)
+        integer, intent(in) :: ng(3)
+        real(rk), allocatable :: Tgc(:,:)
+        integer :: i
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:,:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
-    integer, intent(in) :: degree(3)
-    integer, intent(in) :: nc(3)
-    integer, intent(in) :: ng(3)
-    real(rk), allocatable :: Tgc(:,:)
-    integer :: i
-
-    allocate(Tgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3)))
-    !$omp parallel do
-    do i = 1, size(Xt, 1)
-        Tgc(i,:) = kron(basis_bspline(Xt(i,3), knot3, nc(3), degree(3)), kron(&
-            basis_bspline(Xt(i,2), knot2, nc(2), degree(2)),&
-            basis_bspline(Xt(i,1), knot1, nc(1), degree(1))))
-    end do
-    !$omp end parallel do
-end function
-!===============================================================================
+        allocate(Tgc(ng(1)*ng(2)*ng(3), nc(1)*nc(2)*nc(3)))
+        do concurrent (i = 1: size(Xt, 1))
+            Tgc(i,:) = kron(basis_bspline(Xt(i,3), knot3, nc(3), degree(3)), kron(&
+                basis_bspline(Xt(i,2), knot2, nc(2), degree(2)),&
+                basis_bspline(Xt(i,1), knot1, nc(1), degree(1))))
+        end do
+    end function
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-impure function compute_Tgc_bspline_3d_scalar(Xt, knot1, knot2, knot3, degree, nc) result(Tgc)
-    use forcad_kinds, only: rk
-    use forcad_utils, only: basis_bspline, kron
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function compute_Tgc_bspline_3d_scalar(Xt, knot1, knot2, knot3, degree, nc) result(Tgc)
+        real(rk), intent(in), contiguous :: Xt(:)
+        real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
+        integer, intent(in) :: degree(3)
+        integer, intent(in) :: nc(3)
+        real(rk), allocatable :: Tgc(:)
 
-    implicit none
-    real(rk), intent(in), contiguous :: Xt(:)
-    real(rk), intent(in), contiguous :: knot1(:), knot2(:), knot3(:)
-    integer, intent(in) :: degree(3)
-    integer, intent(in) :: nc(3)
-    real(rk), allocatable :: Tgc(:)
-
-    allocate(Tgc(nc(1)*nc(2)*nc(3)))
-    Tgc= kron(basis_bspline(Xt(3), knot3, nc(3), degree(3)), kron(&
-        basis_bspline(Xt(2), knot2, nc(2), degree(2)),&
-        basis_bspline(Xt(1), knot1, nc(1), degree(1))))
-end function
-!===============================================================================
+        allocate(Tgc(nc(1)*nc(2)*nc(3)))
+        Tgc= kron(basis_bspline(Xt(3), knot3, nc(3), degree(3)), kron(&
+            basis_bspline(Xt(2), knot2, nc(2), degree(2)),&
+            basis_bspline(Xt(1), knot1, nc(1), degree(1))))
+    end function
+    !===============================================================================
 
 
-!===============================================================================
-!> author: Seyed Ali Ghasemi
-!> license: BSD 3-Clause
-pure function nearest_point_help_3d(ng, Xg, point_Xg) result(distances)
-    use forcad_kinds, only: rk
+    !===============================================================================
+    !> author: Seyed Ali Ghasemi
+    !> license: BSD 3-Clause
+    pure function nearest_point_help_3d(ng, Xg, point_Xg) result(distances)
+        integer, intent(in) :: ng(3)
+        real(rk), intent(in), contiguous :: Xg(:,:)
+        real(rk), intent(in), contiguous :: point_Xg(:)
+        real(rk), allocatable :: distances(:)
+        integer :: i
 
-    implicit none
-    integer, intent(in) :: ng(3)
-    real(rk), intent(in), contiguous :: Xg(:,:)
-    real(rk), intent(in), contiguous :: point_Xg(:)
-    real(rk), allocatable :: distances(:)
-    integer :: i
+        allocate(distances(ng(1)*ng(2)*ng(3)))
+        do concurrent (i = 1: ng(1)*ng(2)*ng(3))
+            distances(i) = norm2(Xg(i,:) - point_Xg)
+        end do
+    end function
+    !===============================================================================
 
-    allocate(distances(ng(1)*ng(2)*ng(3)))
-    do concurrent (i = 1: ng(1)*ng(2)*ng(3))
-        distances(i) = norm2(Xg(i,:) - point_Xg)
-    end do
-end function
-!===============================================================================
+end module forcad_nurbs_volume

--- a/src/forcad_nurbs_volume.f90
+++ b/src/forcad_nurbs_volume.f90
@@ -6,7 +6,7 @@ module forcad_nurbs_volume
     use forcad_kinds, only: rk
     use forcad_utils, only: basis_bspline, elemConn_C0, kron, ndgrid, compute_multiplicity, compute_knot_vector, &
         basis_bspline_der, insert_knot_A_5_1, findspan, elevate_degree_A_5_9, hexahedron_Xc, remove_knots_A_5_8, &
-        elemConn_Cn, unique, rotation, det, inv, gauss_leg, export_vtk_legacy, cmp_Tgc_3d, basis_bspline_2der
+        elemConn_Cn, unique, rotation, det, inv, gauss_leg, export_vtk_legacy, basis_bspline_2der
 
     implicit none
 

--- a/src/forcad_utils.f90
+++ b/src/forcad_utils.f90
@@ -590,18 +590,18 @@ contains
         real(rk), intent(in) :: u
         real(rk), allocatable, intent(out) :: UQ(:), Qw(:,:)
         integer, intent(out) :: nq
-        integer :: i, j, L, mp, dim, np
+        integer :: i, j, L, mp, d, np
         real(rk), allocatable :: Rw(:,:)
         real(rk) :: alpha
 
-        dim = size(Pw, 2)
+        d = size(Pw, 2)
         np  = size(Pw, 1) - 1
         mp  = np + p + 1
         nq  = np + r
 
         allocate(UQ(0:mp+r))
-        allocate(Qw(0:nq,1:dim))
-        allocate(Rw(0:p ,1:dim))
+        allocate(Qw(0:nq,1:d))
+        allocate(Rw(0:p ,1:d))
 
         UQ(0:k) = UP(0:k)
         UQ(k+1:k+r) = u
@@ -663,20 +663,20 @@ contains
         real(rk), allocatable, intent(out) :: Xcw_new(:,:), knot_new(:)
         real(rk), allocatable :: bezalfs(:,:), bpts(:,:), ebpts(:,:), Nextbpts(:,:), alfs(:)
         real(rk) :: iinv, alpha1, alpha2, Xth1, Xth2, numer, den
-        integer :: n, lbz, rbz, sv, tr, kj, first, knoti, last, alpha3, dim, nc
+        integer :: n, lbz, rbz, sv, tr, kj, first, knoti, last, alpha3, d, nc
         integer :: i, j, q, s, m, ph, ph2, mpi, mh, r, a, b, Xcwi, oldr, mul
         integer, allocatable :: mlp(:)
 
         nc = size(Xcw,1)
-        dim = size(Xcw,2)
+        d = size(Xcw,2)
         mlp = compute_multiplicity(knot)
         mlp = mlp + t
         nc_new = sum(mlp) - (mlp(1)-1) - 1
-        allocate(Xcw_new(nc_new,dim), source=0.0_rk)
+        allocate(Xcw_new(nc_new,d), source=0.0_rk)
         allocate(bezalfs(degree+1,degree+t+1), source=0.0_rk)
-        allocate(bpts(degree+1,dim), source=0.0_rk)
-        allocate(ebpts(degree+t+1,dim), source=0.0_rk)
-        allocate(Nextbpts(degree+1,dim), source=0.0_rk)
+        allocate(bpts(degree+1,d), source=0.0_rk)
+        allocate(ebpts(degree+t+1,d), source=0.0_rk)
+        allocate(Nextbpts(degree+1,d), source=0.0_rk)
         allocate(alfs(degree), source=0.0_rk)
         n = nc - 1
         m = n + degree + 1
@@ -913,9 +913,9 @@ contains
         integer, intent(out) :: t
         real(rk) :: tol, alfi, alfj
         real(rk), allocatable :: temp(:,:)
-        integer :: i, j, ii, jj, remflag, off, first, last, ord, fout, m, k, n, nc, dim, tt
+        integer :: i, j, ii, jj, remflag, off, first, last, ord, fout, m, k, n, nc, d, tt
 
-        dim = size(Pw,2)
+        d  = size(Pw,2)
         nc = size(Pw,1)
         n = nc
         m = n+p+1
@@ -928,9 +928,9 @@ contains
         knot_copy = knot
 
         ! TODO:
-        tol = 1.0e-6_rk * minval(Pw(:,dim))/(1.0_rk + maxval(sqrt(sum(Pw**2, 2))))
+        tol = 1.0e-6_rk * minval(Pw(:,d))/(1.0_rk + maxval(sqrt(sum(Pw**2, 2))))
 
-        allocate(temp(2*p+1,dim), source=0.0_rk)
+        allocate(temp(2*p+1,d), source=0.0_rk)
         t = 0
         do tt = 0, num-1
             off = first-1

--- a/src/forcad_utils.f90
+++ b/src/forcad_utils.f90
@@ -80,12 +80,12 @@ contains
         integer, intent(in)   :: nc
         real(rk), intent(in)  :: Xt
         real(rk)              :: temp, Xth_i, Xth_i1, Xth_ip, Xth_ip1
-        real(rk), allocatable :: Nt(:,:)
+        real(rk)              :: Nt(nc, 0:degree)
         integer               :: i, p
-        real(rk), allocatable :: B(:)
+        real(rk)              :: B(nc)
 
         temp = abs(Xt - knot(size(knot)))
-        allocate(Nt(nc, 0:degree), source=0.0_rk)
+        Nt = 0.0_rk
 
         do p = 0, degree
             do concurrent (i = 1:nc)
@@ -112,8 +112,8 @@ contains
         real(rk), intent(in), contiguous :: knot(:)
         integer, intent(in)   :: nc
         real(rk), intent(in)  :: Xt
-        real(rk), allocatable, intent(out) :: dB(:)
-        real(rk), allocatable, intent(out), optional :: B(:)
+        real(rk), intent(out) :: dB(nc)
+        real(rk), intent(out), optional :: B(nc)
         real(rk), allocatable :: N(:,:), dN_dXt(:,:)
         real(rk)              :: temp, Xth_i, Xth_i1, Xth_ip, Xth_ip1
         integer               :: i, p
@@ -159,9 +159,9 @@ contains
         real(rk), intent(in), contiguous :: knot(:)
         integer, intent(in)   :: nc
         real(rk), intent(in)  :: Xt
-        real(rk), allocatable, intent(out) :: d2B(:)
-        real(rk), allocatable, intent(out), optional :: dB(:)
-        real(rk), allocatable, intent(out), optional :: B(:)
+        real(rk), intent(out) :: d2B(nc)
+        real(rk), intent(out), optional :: dB(nc)
+        real(rk), intent(out), optional :: B(nc)
         real(rk), allocatable :: N(:,:), dN_dXt(:,:), d2N_dXt2(:,:)
         real(rk)              :: temp, Xth_i, Xth_i1, Xth_ip, Xth_ip1
         integer               :: i, p
@@ -1399,6 +1399,5 @@ contains
         end if
     end subroutine
     !===============================================================================
-
 
 end module forcad_utils

--- a/src/forcad_utils.f90
+++ b/src/forcad_utils.f90
@@ -1285,7 +1285,7 @@ contains
         integer, intent(in) :: vtkCellType
         character(len=*), intent(in), optional :: encoding
 
-        integer :: i, j, ne, np, nn, n, nunit
+        integer :: i, ne, np, nn, n, nunit
         character(len=6) :: encoding_
         integer, parameter :: dp = kind(1.0d0)
 

--- a/test/test_nurbs_curve.f90
+++ b/test/test_nurbs_curve.f90
@@ -234,10 +234,10 @@ program test_nurbs_curve
     call nurbs%derivative(Xt=[(real(i-1, rk) / real(23-1, rk), i=1, 23)], dTgc=dTgc, Tgc=Tgc)
     call bsp%derivative(Xt=[(real(i-1, rk) / real(23-1, rk), i=1, 23)], dTgc=dTgcb, Tgc=Tgcb)
 
-    call nurbs%derivative(Xt=0.0_rk, dTgc=dTgc1b, Tgc=Tgc1b)
+    call nurbs%derivative(Xt=0.0_rk, dTgc=dTgc1, Tgc=Tgc1)
     call bsp%derivative(Xt=0.0_rk, dTgc=dTgc1b, Tgc=Tgc1b)
 
-    call nurbs%derivative(Xt=0.0_rk, dTgc=dTgc1b, Tgc=Tgc1b, elem=[1,2,3])
+    call nurbs%derivative(Xt=0.0_rk, dTgc=dTgc1, Tgc=Tgc1, elem=[1,2,3])
     call bsp%derivative(Xt=0.0_rk, dTgc=dTgc1b, Tgc=Tgc1b, elem=[1,2,3])
 
     call nurbs%derivative2(res=23, d2Tgc=d2Tgc, dTgc=dTgc, Tgc=Tgc)
@@ -246,10 +246,10 @@ program test_nurbs_curve
     call nurbs%derivative2(Xt=[(real(i-1, rk) / real(23-1, rk), i=1, 23)], d2Tgc=d2Tgc, dTgc=dTgc, Tgc=Tgc)
     call bsp%derivative2(Xt=[(real(i-1, rk) / real(23-1, rk), i=1, 23)], d2Tgc=d2Tgcb, dTgc=dTgcb, Tgc=Tgcb)
 
-    call nurbs%derivative2(Xt=0.0_rk, d2Tgc=d2Tgc1, dTgc=dTgc1b, Tgc=Tgc1b)
+    call nurbs%derivative2(Xt=0.0_rk, d2Tgc=d2Tgc1, dTgc=dTgc1, Tgc=Tgc1b)
     call bsp%derivative2(Xt=0.0_rk, d2Tgc=d2Tgc1b, dTgc=dTgc1b, Tgc=Tgc1b)
 
-    call nurbs%derivative2(Xt=0.0_rk, d2Tgc=d2Tgc1, dTgc=dTgc1b, Tgc=Tgc1b)
+    call nurbs%derivative2(Xt=0.0_rk, d2Tgc=d2Tgc1, dTgc=dTgc1, Tgc=Tgc1b)
     call bsp%derivative2(Xt=0.0_rk, d2Tgc=d2Tgc1b, dTgc=dTgc1b, Tgc=Tgc1b)
 
     call nurbs%rotate_Xc(45.0_rk, 0.0_rk, 0.0_rk)

--- a/test/test_nurbs_curve.f90
+++ b/test/test_nurbs_curve.f90
@@ -246,10 +246,10 @@ program test_nurbs_curve
     call nurbs%derivative2(Xt=[(real(i-1, rk) / real(23-1, rk), i=1, 23)], d2Tgc=d2Tgc, dTgc=dTgc, Tgc=Tgc)
     call bsp%derivative2(Xt=[(real(i-1, rk) / real(23-1, rk), i=1, 23)], d2Tgc=d2Tgcb, dTgc=dTgcb, Tgc=Tgcb)
 
-    call nurbs%derivative2(Xt=0.0_rk, d2Tgc=d2Tgc1, dTgc=dTgc1, Tgc=Tgc1b)
+    call nurbs%derivative2(Xt=0.0_rk, d2Tgc=d2Tgc1, dTgc=dTgc1, Tgc=Tgc1)
     call bsp%derivative2(Xt=0.0_rk, d2Tgc=d2Tgc1b, dTgc=dTgc1b, Tgc=Tgc1b)
 
-    call nurbs%derivative2(Xt=0.0_rk, d2Tgc=d2Tgc1, dTgc=dTgc1, Tgc=Tgc1b)
+    call nurbs%derivative2(Xt=0.0_rk, d2Tgc=d2Tgc1, dTgc=dTgc1, Tgc=Tgc1)
     call bsp%derivative2(Xt=0.0_rk, d2Tgc=d2Tgc1b, dTgc=dTgc1b, Tgc=Tgc1b)
 
     call nurbs%rotate_Xc(45.0_rk, 0.0_rk, 0.0_rk)

--- a/test/test_nurbs_surface.f90
+++ b/test/test_nurbs_surface.f90
@@ -239,10 +239,10 @@ program test_nurbs_surface
     call bsp%derivative(&
         Xt1=[(real(i-1, rk) / real(30-1, rk), i=1, 30)], Xt2=[(real(i-1, rk) / real(30-1, rk), i=1, 30)], dTgc=dTgcb, Tgc=Tgcb)
 
-    call nurbs%derivative(Xt=[0.0_rk,0.0_rk], dTgc=dTgc1b, Tgc=Tgc1b)
+    call nurbs%derivative(Xt=[0.0_rk,0.0_rk], dTgc=dTgc1, Tgc=Tgc1)
     call bsp%derivative(Xt=[0.0_rk,0.0_rk], dTgc=dTgc1b, Tgc=Tgc1b)
 
-    call nurbs%derivative(Xt=[0.0_rk,0.0_rk], dTgc=dTgc1b, Tgc=Tgc1b, elem=[1,2,3])
+    call nurbs%derivative(Xt=[0.0_rk,0.0_rk], dTgc=dTgc1, Tgc=Tgc1, elem=[1,2,3])
     call bsp%derivative(Xt=[0.0_rk,0.0_rk], dTgc=dTgc1b, Tgc=Tgc1b, elem=[1,2,3])
 
     call nurbs%derivative2(res1=30, res2=30, d2Tgc=d2Tgc, dTgc=dTgc, Tgc=Tgc)
@@ -255,10 +255,10 @@ program test_nurbs_surface
         Xt1=[(real(i-1, rk) / real(30-1, rk), i=1, 30)], Xt2=[(real(i-1, rk) / real(30-1, rk), i=1, 30)],&
         d2Tgc=d2Tgcb, dTgc=dTgcb, Tgc=Tgcb)
 
-    call nurbs%derivative2(Xt=[0.0_rk,0.0_rk], d2Tgc=d2Tgc1, dTgc=dTgc1b, Tgc=Tgc1b)
+    call nurbs%derivative2(Xt=[0.0_rk,0.0_rk], d2Tgc=d2Tgc1, dTgc=dTgc1, Tgc=Tgc1)
     call bsp%derivative2(Xt=[0.0_rk,0.0_rk], d2Tgc=d2Tgc1b, dTgc=dTgc1b, Tgc=Tgc1b)
 
-    call nurbs%derivative2(Xt=[0.0_rk,0.0_rk], d2Tgc=d2Tgc1, dTgc=dTgc1b, Tgc=Tgc1b)
+    call nurbs%derivative2(Xt=[0.0_rk,0.0_rk], d2Tgc=d2Tgc1, dTgc=dTgc1, Tgc=Tgc1)
     call bsp%derivative2(Xt=[0.0_rk,0.0_rk], d2Tgc=d2Tgc1b, dTgc=dTgc1b, Tgc=Tgc1b)
 
     call nurbs%rotate_Xc(45.0_rk, 0.0_rk, 0.0_rk)

--- a/test/test_nurbs_volume.f90
+++ b/test/test_nurbs_volume.f90
@@ -245,10 +245,10 @@ program test_nurbs_volume
         Xt2=[(real(i-1, rk) / real(20-1, rk), i=1, 20)],&
         Xt3=[(real(i-1, rk) / real(20-1, rk), i=1, 20)], dTgc=dTgcb, Tgc=Tgcb)
 
-    call nurbs%derivative(Xt=[0.0_rk,0.0_rk,0.0_rk], dTgc=dTgc1b, Tgc=Tgc1b)
+    call nurbs%derivative(Xt=[0.0_rk,0.0_rk,0.0_rk], dTgc=dTgc1, Tgc=Tgc1)
     call bsp%derivative(Xt=[0.0_rk,0.0_rk,0.0_rk], dTgc=dTgc1b, Tgc=Tgc1b)
 
-    call nurbs%derivative(Xt=[0.0_rk,0.0_rk,0.0_rk], dTgc=dTgc1b, Tgc=Tgc1b, elem=[1,2,3])
+    call nurbs%derivative(Xt=[0.0_rk,0.0_rk,0.0_rk], dTgc=dTgc1, Tgc=Tgc1, elem=[1,2,3])
     call bsp%derivative(Xt=[0.0_rk,0.0_rk,0.0_rk], dTgc=dTgc1b, Tgc=Tgc1b, elem=[1,2,3])
 
     call nurbs%derivative2(res1=20, res2=20, res3=20, d2Tgc=d2Tgc, dTgc=dTgc, Tgc=Tgc)


### PR DESCRIPTION
- Replace OpenMP with do concurrent
- Move external procedures into corresponding modules.
- Add new module procedure interfaces.
- Remove unnecessary explicit interfaces.
- Replace some allocatable arrays with fixed-size arrays.
- Update fortitude ignore list
- Remove unused procedure from module imports
- Update derivative calls in nurbs tests
- Remove unused variable 'j'
- Rename variable 'dim' to 'd'