### PR TITLE
chore: exclude examples and logo dirs, update README badges

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  ignore:
+    - "example/**"
+    - "logo/**"
+    - "build/dependencies/**"

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -29,4 +29,3 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true
-        exclude: "build/dependencies"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 [![GitHub](https://img.shields.io/badge/GitHub-ForCAD-blue.svg?style=social&logo=github)](https://github.com/gha3mi/forcad)
 [![Documentation](https://img.shields.io/badge/ford-Documentation%20-blueviolet.svg)](https://gha3mi.github.io/forcad/)
-[![fpm](https://github.com/gha3mi/forcad/actions/workflows/fpm.yml/badge.svg)](https://github.com/gha3mi/forcad/actions/workflows/fpm.yml)
-[![doc](https://github.com/gha3mi/forcad/actions/workflows/doc.yml/badge.svg)](https://github.com/gha3mi/forcad/actions/workflows/doc.yml) 
-[![codecov](https://codecov.io/gh/gha3mi/forcad/branch/dev/graph/badge.svg?token=N69NG6C86I)](https://codecov.io/gh/gha3mi/forcad)
+[![Setup Fortran Conda CI/CD](https://github.com/gha3mi/forcad/actions/workflows/CI-CD.yml/badge.svg?branch=main)](https://github.com/gha3mi/forcad/actions/workflows/CI-CD.yml)
+[![codecov](https://codecov.io/gh/gha3mi/forcad/branch/main/graph/badge.svg?token=N69NG6C86I)](https://codecov.io/gh/gha3mi/forcad)
 [![License](https://img.shields.io/github/license/gha3mi/forcad?color=green)](https://github.com/gha3mi/forcad/blob/main/LICENSE)
 [![DOI](https://zenodo.org/badge/778032800.svg)](https://zenodo.org/doi/10.5281/zenodo.10904447)
 


### PR DESCRIPTION
Excluded `example/` and `logo/` directories from coverage collection to improve accuracy. Updated README badges to reflect the latest CI/CD workflows and status.